### PR TITLE
[Feature] support modify text-align of a line after layout

### DIFF
--- a/demos/darwin/macos/ttreaderdemo/paragraph_test.h
+++ b/demos/darwin/macos/ttreaderdemo/paragraph_test.h
@@ -150,6 +150,7 @@ class ParagraphTest {
   void TestItalicFont(ICanvasHelper* canvas, float width) const;
   void TestCJKBreak(ICanvasHelper* canvas, float width) const;
   void TestAlignWithBBox(ICanvasHelper* canvas, float width) const;
+  void TestModifyHAlignAfterLayout(ICanvasHelper* canvas, float width) const;
 
  private:
   uint32_t test_width = 490;

--- a/examples/demo_images/horizontal_alignment_modify.png
+++ b/examples/demo_images/horizontal_alignment_modify.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:82bdcf53109e4a1e0475c1b7447f7e2711ce5e1ef4f6ee275057617ad0245f94
+size 32295

--- a/examples/json_data/horizontal_alignment_modify.json
+++ b/examples/json_data/horizontal_alignment_modify.json
@@ -1,0 +1,53 @@
+{
+  "paragraphs": [
+    {
+      "paragraph_style": {
+        "horizontal_alignment": "kLeft"
+      },
+      "runs": [
+        {
+          "type": "text",
+          "content": "This is a long sentence which is too long to fitin one line."
+        },
+        {
+          "type": "text",
+          "content": "This is a long sentence which is too long to fit in one line."
+        },
+        {
+          "type": "text",
+          "content": "This is a long sentence which is too long to fit in one line."
+        }
+      ]
+    }
+  ],
+  "layout_region": {
+    "regions": [
+      {
+        "width": 640.0,
+        "height": 200.0,
+        "width_mode": "kDefinite",
+        "height_mode": "kAtMost"
+      }
+    ]
+  },
+  "modifiers": [
+    {
+      "type": "ModifyLineHAlign",
+      "region_index": 0,
+      "line_index": 1,
+      "value": "kJustify"
+    },
+    {
+      "type": "ModifyLineHAlign",
+      "region_index": 0,
+      "line_index": 2,
+      "value": "kCenter"
+    },
+    {
+      "type": "ModifyLineHAlign",
+      "region_index": 0,
+      "line_index": 3,
+      "value": "kRight"
+    }
+  ]
+}

--- a/examples/json_parser/json_parser.h
+++ b/examples/json_parser/json_parser.h
@@ -21,10 +21,17 @@ struct DebugSettings {
   bool draw_line_rectangle_ = false;
 };
 
+struct ModifyHAlignParams {
+  int32_t region_index_{0};
+  int32_t line_index_{0};
+  ParagraphHorizontalAlignment alignment_{ParagraphHorizontalAlignment::kLeft};
+};
+
 struct JsonDocumentContent {
   std::vector<std::unique_ptr<Paragraph>> paragraphs_;
   std::vector<std::unique_ptr<LayoutRegion>> layout_regions_;
   std::unique_ptr<TTTextContext> tttext_context_;
+  std::vector<ModifyHAlignParams> modify_align_params_;
   DebugSettings debug_settings_;
 };
 

--- a/examples/json_parser/specification.json
+++ b/examples/json_parser/specification.json
@@ -288,6 +288,19 @@
             }
         ]
     },
+    // other extra modifiers
+    "modifiers": [
+        {
+            // [String] type of modifier, supported values: ["ModifyLineHAlign"]
+            "type": "ModifyLineHAlign",
+            // [Number] which region, Default 0,
+            "region_index": 0,
+            // [Number] which line, Default 0,
+            "line_index": 0,
+            // [String] h-align that apply to the line
+            "value": "kLeft"
+        }
+    ],
     "debug_settings": {
         // Whether to draw line rectangles
         // [Boolean] Whether to draw line rectangles

--- a/public/textra/text_line.h
+++ b/public/textra/text_line.h
@@ -99,6 +99,13 @@ class L_EXPORT TextLine {
   float GetStartIndent() const { return start_indent_; }
   float GetEndIndent() const { return end_indent_; }
 
+  /**
+   * Modify HorizontalAlignment of this line, must be called **AFTER** layout.
+   * @param h_align target alignment
+   */
+  virtual void ModifyHorizontalAlignment(
+      ParagraphHorizontalAlignment h_align) = 0;
+
  protected:
   float line_top_ = 0;
   float max_ascent_ = 0;   // distance from linetop to baseline

--- a/src/textlayout/text_line_impl.cc
+++ b/src/textlayout/text_line_impl.cc
@@ -235,8 +235,22 @@ void TextLineImpl::AppendGhostRun(std::unique_ptr<BaseRun> ghost_run) {
   extra_contents_.emplace_back(std::move(ghost_run));
 }
 
+void TextLineImpl::ModifyHorizontalAlignment(
+    ParagraphHorizontalAlignment h_align) {
+  if (h_align == ParagraphHorizontalAlignment::kJustify &&
+      paragraph_->GetParagraphStyle().GetHorizontalAlign() !=
+          ParagraphHorizontalAlignment::kJustify) {
+    CreateDrawerPiece();
+  }
+  ApplyAlignment(h_align);
+}
+
 void TextLineImpl::ApplyAlignment() {
-  const auto align = paragraph_->GetParagraphStyle().GetHorizontalAlign();
+  ApplyAlignment(paragraph_->GetParagraphStyle().GetHorizontalAlign());
+}
+
+void TextLineImpl::ApplyAlignment(ParagraphHorizontalAlignment h_align) {
+  const auto align = h_align;
   auto drawer_iter_begin = drawer_list_.begin();
   while (drawer_iter_begin != drawer_list_.end()) {
     const auto* line_range = (*drawer_iter_begin)->GetParent();

--- a/src/textlayout/text_line_impl.h
+++ b/src/textlayout/text_line_impl.h
@@ -64,6 +64,8 @@ class TextLineImpl : public TextLine {
   }
   void UpdateXMax(float width) override;
   void ApplyAlignment() override;
+  void ApplyAlignment(ParagraphHorizontalAlignment h_align);
+  void ModifyHorizontalAlignment(ParagraphHorizontalAlignment h_align) override;
   bool StripContentByWidth(float space);
   void AppendGhostRun(std::unique_ptr<BaseRun> ghost_run);
   TTStringPiece GetText() const;


### PR DESCRIPTION
add a `ModifyHorizontalAlignment(ParagraphHorizontalAlignment)` method for `TextLine` class.