### PR TITLE
[BugFix] fix some bugs

### DIFF
--- a/platform/android/lynxtextra/src/main/java/com/lynx/textra/JavaFontManager.java
+++ b/platform/android/lynxtextra/src/main/java/com/lynx/textra/JavaFontManager.java
@@ -40,6 +40,7 @@ public class JavaFontManager {
       mFontList.add(cached_typeface);
       cached_typeface = RegisterTypeface(typeface, key, CreateNativeTypeface(mNativeHandler));
     }
+    mFontMap.put(key, cached_typeface);
     return cached_typeface;
   }
 

--- a/src/ports/shaper/coretext/shaper_core_text.h
+++ b/src/ports/shaper/coretext/shaper_core_text.h
@@ -16,6 +16,7 @@
 namespace ttoffice {
 namespace tttext {
 class RunStyle;
+constexpr uint32_t SHAPER_BUFF_SIZE = 1024;
 class ShaperCoreText : public TTShaper {
  public:
   ShaperCoreText() = delete;
@@ -38,6 +39,7 @@ class ShaperCoreText : public TTShaper {
  private:
   mutable std::vector<TypefaceRef> ct_font_lst_;
   mutable CTFontDescriptorRef default_font_desc_ = nullptr;
+  mutable uint32_t tmp_buf_[SHAPER_BUFF_SIZE];
 };
 }  // namespace tttext
 }  // namespace ttoffice

--- a/src/ports/shaper/coretext/shaper_core_text.mm
+++ b/src/ports/shaper/coretext/shaper_core_text.mm
@@ -39,7 +39,10 @@ void ShaperCoreText::ProcessBidirection(const char32_t* text, uint32_t length,
                                         uint32_t* logical_map,
                                         uint8_t* dir_vec) {
   auto u16_str = ttoffice::base::U32StringToU16(text, length);
-  uint32_t u16_to_u32_map[u16_str.length() + 1];
+  uint32_t* u16_to_u32_map = tmp_buf_;
+  if (u16_str.length() + 1 > SHAPER_BUFF_SIZE) {
+    u16_to_u32_map = new uint32_t[u16_str.length() + 1];
+  }
   CTWritingDirection direction = kCTWritingDirectionNatural;
   if (write_direction == WriteDirection::kLTR ||
       write_direction == WriteDirection::kTTB) {
@@ -87,6 +90,9 @@ void ShaperCoreText::ProcessBidirection(const char32_t* text, uint32_t length,
         visual_map[char_start + k] = static_cast<unsigned int>(order++);
       }
     }
+  }
+  if (u16_to_u32_map != tmp_buf_) {
+    delete[] u16_to_u32_map;
   }
   CFRelease(attr_text);
   CFRelease(dict);
@@ -155,7 +161,10 @@ void ShaperCoreText::OnShapeText(const ShapeKey& key,
   CFDictionaryRef attributes = GenerateAttributes(key);
   auto u16_str = base::U32StringToU16(
       key.text_.data(), static_cast<uint32_t>(key.text_.length()));
-  uint32_t u16_char_map[u16_str.length() + 1];
+  uint32_t* u16_char_map = tmp_buf_;
+  if (u16_str.length() + 1 > SHAPER_BUFF_SIZE) {
+    u16_char_map = new uint32_t[u16_str.length() + 1];
+  }
   auto cfa = GenerateAttributeString(u16_str.data(),
                                      static_cast<uint32_t>(u16_str.length()),
                                      u16_char_map, attributes);
@@ -219,6 +228,9 @@ void ShaperCoreText::OnShapeText(const ShapeKey& key,
                            static_cast<int32_t>(char_count), is_rtl);
   }
   result->AppendPlatformShapingResult(ct_result);
+  if (u16_char_map != tmp_buf_) {
+    delete[] u16_char_map;
+  }
   CFRelease(attributes);
   CFRelease(cfa);
   CFRelease(line);


### PR DESCRIPTION
- the process of register typeface in JavaFontManager was incorrect, which may lead to crash when matching typeface by name.
- fix the process of shaper_core_text to prevent stack overflow when shaping large text.