### PR TITLE
[BugFix] fix ghost run was mistakenly removed

### DIFF
--- a/src/textlayout/text_line_impl.cc
+++ b/src/textlayout/text_line_impl.cc
@@ -155,6 +155,9 @@ void TextLineImpl::CreateDrawerPiece() {
   auto last = drawer_list_.rbegin();
   while (last != drawer_list_.rend()) {
     auto& drawer = *last;
+    if (drawer->GetRun()->IsGhostRun()) {
+      break;
+    }
     auto start_char_index = drawer->GetStartCharPosInParagraph();
     auto last_char_index = drawer->GetEndCharPosInParagraph();
     auto content = paragraph_->GetContent();


### PR DESCRIPTION
Ghost run was mistakenly removed when removing trailing spaces. Fix it by skip the remove logic when the run at the end of line is a ghost run.

issue: #42