### PR TITLE
[Feature] support dominant baseline and tight char-range bounds

### DIFF
--- a/demos/darwin/macos/ttreaderdemo/paragraph_test.cc
+++ b/demos/darwin/macos/ttreaderdemo/paragraph_test.cc
@@ -59,6 +59,22 @@ void ParagraphTest::DrawParagraph(ICanvasHelper* canvas, Paragraph& paragraph,
     paint->SetStrokeColor(TTColor::GREEN);
     canvas->DrawRect(0, 0, layout_width, layout_height, paint.get());
   }
+  if (draw_tight_bound_) {
+    paint->SetStrokeWidth(1);
+    int line_count = page.GetLineCount();
+    for (int i = 0; i < line_count; i++) {
+      auto line = page.GetLine(0);
+      auto baseline = line->GetLineBaseLine();
+      paint->SetStrokeColor(TTColor::BLUE);
+      canvas->DrawLine(0, baseline, layout_width, baseline, paint.get());
+      float bound[4];
+      line->GetTightBoundingRectByCharRange(bound, line->GetStartCharPos(),
+                                            line->GetEndCharPos());
+      paint->SetStrokeColor(TTColor::RED);
+      canvas->DrawRect(bound[0], bound[1] + baseline, bound[2],
+                       bound[3] + baseline, paint.get());
+    }
+  }
 }
 
 std::vector<std::pair<std::string, ParagraphTest::TestCaseFunction>>
@@ -115,6 +131,7 @@ ParagraphTest::GetTestCases() {
           {"TestApplyStyleInRange", &ParagraphTest::TestApplyStyleInRange},
           {"TestTextShadow", &ParagraphTest::TestTextShadow},
           {"TestHalfLeading", &ParagraphTest::TestHalfLeading},
+          {"TestDominateBaseline", &ParagraphTest::TestDominateBaseline},
       };
   return kTestCases;
 }
@@ -1708,4 +1725,131 @@ void ParagraphTest::TestHalfLeading(ICanvasHelper* canvas, float width) const {
     canvas->Restore();
   }
 }
+void ParagraphTest::TestDominateBaseline(ICanvasHelper* canvas,
+                                         float width) const {
+  draw_page_bound_ = false;
+  draw_tight_bound_ = true;
+  {
+    canvas->Save();
+    canvas->Translate(10, 10);
+    Style style;
+    style.SetBackgroundColor(TTColor(0x0F0000FF));
+    auto para = Paragraph::Create();
+    ParagraphStyle para_style;
+    para_style.SetDominantBaseline(DominantBaseline::kTop);
+    para->SetParagraphStyle(&para_style);
+    FontDescriptor fd;
+    fd.font_style_ = FontStyle::Normal();
+    fd.font_family_list_.emplace_back("NotoSansCJK");
+    style.SetFontDescriptor(fd);
+    style.SetTextSize(24);
+    para->AddTextRun(&style, "Top");
+    DrawParagraph(canvas, *para, width, LayoutMode::kAtMost,
+                  LayoutMode::kIndefinite);
+
+    canvas->Restore();
+  }
+  {
+    canvas->Save();
+    canvas->Translate(100, 10);
+    Style style;
+    style.SetBackgroundColor(TTColor(0x0F0000FF));
+    auto para = Paragraph::Create();
+    ParagraphStyle para_style;
+    para_style.SetDominantBaseline(DominantBaseline::kMiddle);
+    para->SetParagraphStyle(&para_style);
+    FontDescriptor fd;
+    fd.font_style_ = FontStyle::Normal();
+    fd.font_family_list_.emplace_back("NotoSansCJK");
+    style.SetFontDescriptor(fd);
+    style.SetTextSize(24);
+    para->AddTextRun(&style, "Middle");
+    DrawParagraph(canvas, *para, width, LayoutMode::kAtMost,
+                  LayoutMode::kIndefinite);
+
+    canvas->Restore();
+  }
+  {
+    canvas->Save();
+    canvas->Translate(200, 10);
+    Style style;
+    style.SetBackgroundColor(TTColor(0x0F0000FF));
+    auto para = Paragraph::Create();
+    ParagraphStyle para_style;
+    para_style.SetDominantBaseline(DominantBaseline::kBottom);
+    para->SetParagraphStyle(&para_style);
+    FontDescriptor fd;
+    fd.font_style_ = FontStyle::Normal();
+    fd.font_family_list_.emplace_back("NotoSansCJK");
+    style.SetFontDescriptor(fd);
+    style.SetTextSize(24);
+    para->AddTextRun(&style, "Bottom");
+    DrawParagraph(canvas, *para, width, LayoutMode::kAtMost,
+                  LayoutMode::kIndefinite);
+
+    canvas->Restore();
+  }
+  {
+    canvas->Save();
+    canvas->Translate(300, 10);
+    Style style;
+    style.SetBackgroundColor(TTColor(0x0F0000FF));
+    auto para = Paragraph::Create();
+    ParagraphStyle para_style;
+    para_style.SetDominantBaseline(DominantBaseline::kAlphabetic);
+    para->SetParagraphStyle(&para_style);
+    FontDescriptor fd;
+    fd.font_style_ = FontStyle::Normal();
+    fd.font_family_list_.emplace_back("NotoSansCJK");
+    style.SetFontDescriptor(fd);
+    style.SetTextSize(50);
+    para->AddTextRun(&style, "test");
+    DrawParagraph(canvas, *para, width, LayoutMode::kAtMost,
+                  LayoutMode::kIndefinite);
+
+    canvas->Restore();
+  }
+  {
+    canvas->Save();
+    canvas->Translate(450, 10);
+    Style style;
+    style.SetBackgroundColor(TTColor(0x0F0000FF));
+    auto para = Paragraph::Create();
+    ParagraphStyle para_style;
+    para_style.SetDominantBaseline(DominantBaseline::kHanging);
+    para->SetParagraphStyle(&para_style);
+    FontDescriptor fd;
+    fd.font_style_ = FontStyle::Normal();
+    fd.font_family_list_.emplace_back("NotoSansCJK");
+    style.SetFontDescriptor(fd);
+    style.SetTextSize(24);
+    para->AddTextRun(&style, "Hanging");
+    DrawParagraph(canvas, *para, width, LayoutMode::kAtMost,
+                  LayoutMode::kIndefinite);
+
+    canvas->Restore();
+  }
+  {
+    canvas->Save();
+    canvas->Translate(550, 10);
+    Style style;
+    style.SetBackgroundColor(TTColor(0x0F0000FF));
+    auto para = Paragraph::Create();
+    ParagraphStyle para_style;
+    para_style.SetDominantBaseline(DominantBaseline::kIdeographic);
+    para->SetParagraphStyle(&para_style);
+    FontDescriptor fd;
+    fd.font_style_ = FontStyle::Normal();
+    fd.font_family_list_.emplace_back("NotoSansCJK");
+    style.SetFontDescriptor(fd);
+    style.SetTextSize(24);
+    para->AddTextRun(&style, "Ideographic");
+    DrawParagraph(canvas, *para, width, LayoutMode::kAtMost,
+                  LayoutMode::kIndefinite);
+
+    canvas->Restore();
+  }
+  draw_tight_bound_ = false;
+}
+
 #pragma clang diagnostic pop

--- a/demos/darwin/macos/ttreaderdemo/paragraph_test.h
+++ b/demos/darwin/macos/ttreaderdemo/paragraph_test.h
@@ -155,12 +155,14 @@ class ParagraphTest {
   void TestApplyStyleInRange(ICanvasHelper* canvas, float width) const;
   void TestTextShadow(ICanvasHelper* canvas, float width) const;
   void TestHalfLeading(ICanvasHelper* canvas, float width) const;
+  void TestDominateBaseline(ICanvasHelper* canvas, float width) const;
 
  private:
   uint32_t test_width = 490;
   uint32_t test_height = 1000;
   mutable bool draw_page_bound_ = true;
   mutable bool draw_layouted_bound_ = true;
+  mutable bool draw_tight_bound_ = false;
 
  private:
   ShaperType shaper_type_;

--- a/examples/json_parser/json_parser.cc
+++ b/examples/json_parser/json_parser.cc
@@ -443,6 +443,26 @@ ParagraphStyle ParseParagraphStyle(const Value& style_data) {
     }
   }
 
+  if (HasOptionalField(style_data, "dominant_baseline")) {
+    auto baseline =
+        GetRequiredField<std::string>(style_data, "dominant_baseline");
+    if (baseline == "kAlphabetic") {
+      para_style.SetDominantBaseline(DominantBaseline::kAlphabetic);
+    } else if (baseline == "kTop") {
+      para_style.SetDominantBaseline(DominantBaseline::kTop);
+    } else if (baseline == "kMiddle") {
+      para_style.SetDominantBaseline(DominantBaseline::kMiddle);
+    } else if (baseline == "kBottom") {
+      para_style.SetDominantBaseline(DominantBaseline::kBottom);
+    } else if (baseline == "kHanging") {
+      para_style.SetDominantBaseline(DominantBaseline::kHanging);
+    } else if (baseline == "kIdeographic") {
+      para_style.SetDominantBaseline(DominantBaseline::kIdeographic);
+    } else {
+      throw std::runtime_error("Invalid dominant_baseline value: " + baseline);
+    }
+  }
+
   // Parse default_style
   if (HasOptionalField(style_data, "default_style")) {
     Style default_style = ParseStyle(style_data["default_style"]);

--- a/public/textra/layout_definition.h
+++ b/public/textra/layout_definition.h
@@ -192,6 +192,14 @@ enum FeatureOption : uint8_t {
   kHarmonyShaperForceUseLowAPI,
   kSystemFontAdjust,
 };
+enum class DominantBaseline : uint8_t {
+  kAlphabetic,
+  kTop,
+  kMiddle,
+  kBottom,
+  kIdeographic,
+  kHanging,
+};
 }  // namespace tttext
 }  // namespace ttoffice
 #endif  // PUBLIC_TEXTRA_LAYOUT_DEFINITION_H_

--- a/public/textra/paragraph_style.h
+++ b/public/textra/paragraph_style.h
@@ -100,6 +100,27 @@ class L_EXPORT ParagraphStyle {
   }
 
   /**
+   * @brief Dominant baseline used to align runs within each line.
+   *
+   * Controls where the line's baseline is placed relative to the line box
+   * (e.g. top/middle/bottom), and shifts all runs in the line accordingly so
+   * they share the same dominant baseline.
+   *
+   * Default is DominantBaseline::kAlphabetic (traditional text baseline).
+   *
+   * @note This affects line baseline related APIs such as
+   * TextLine::GetLineBaseLine() and tight bounding box APIs such as
+   * TextLine::GetTightBoundingRectByCharRange() (which reports ascent/descent
+   * relative to the line baseline).
+   *
+   * @see DominantBaseline enum for available values.
+   */
+  DominantBaseline GetDominantBaseline() const { return dominant_baseline_; }
+  void SetDominantBaseline(DominantBaseline dominant_baseline) {
+    dominant_baseline_ = dominant_baseline;
+  }
+
+  /**
    * @brief Start indentation in pixels.
    *
    * Sets or gets the indentation from the start edge of the paragraph
@@ -558,6 +579,7 @@ class L_EXPORT ParagraphStyle {
  protected:
   ParagraphHorizontalAlignment horizontal_alignment_;
   ParagraphVerticalAlignment vertical_alignment_;
+  DominantBaseline dominant_baseline_;
   Style default_style_;
   std::unique_ptr<Indent> indent_;
   std::unique_ptr<Spacing> spacing_;

--- a/public/textra/text_line.h
+++ b/public/textra/text_line.h
@@ -90,6 +90,16 @@ class L_EXPORT TextLine {
                                           CharPos start_char_pos,
                                           CharPos end_char_pos) const = 0;
   /**
+   *
+   * @param start_char_pos paragraph text offset index
+   * @param end_char_pos paragraph text offset index
+   * @param bounding_rect return value, [left, ascent, right, descent]
+   *        ascent = top - baseline, descent = bottom - baseline
+   */
+  virtual void GetTightBoundingRectByCharRange(float bounding_rect[4],
+                                               CharPos start_char_pos,
+                                               CharPos end_char_pos) const = 0;
+  /**
    * Get CharPos based on x coordinate, character offset relative to
    * LineStartPos, first character ID at line start is 0
    * @param x x coordinate

--- a/src/textlayout/style/paragraph_style.cc
+++ b/src/textlayout/style/paragraph_style.cc
@@ -16,6 +16,7 @@ namespace tttext {
 ParagraphStyle::ParagraphStyle()
     : horizontal_alignment_(ParagraphHorizontalAlignment::kLeft),
       vertical_alignment_(ParagraphVerticalAlignment::kCenter),
+      dominant_baseline_(DominantBaseline::kAlphabetic),
       default_style_(Style::DefaultStyle()),
       indent_(std::make_unique<Indent>()),
       spacing_(std::make_unique<Spacing>()),
@@ -38,6 +39,7 @@ ParagraphStyle& ParagraphStyle::operator=(
   if (this == &paragraph_style) return *this;
   horizontal_alignment_ = paragraph_style.horizontal_alignment_;
   vertical_alignment_ = paragraph_style.vertical_alignment_;
+  dominant_baseline_ = paragraph_style.dominant_baseline_;
   default_style_ = paragraph_style.default_style_;
   *indent_ = *paragraph_style.indent_;
   *spacing_ = *paragraph_style.spacing_;

--- a/src/textlayout/text_layout_impl.cc
+++ b/src/textlayout/text_layout_impl.cc
@@ -86,6 +86,7 @@ void TextLayoutImpl::FinishLineLayout(LayoutRegion* page,
     line->TrimTailSpace();
   }
   line->ApplyAlignment();
+  line->ApplyDominateBaseline();
   /*
    * Extra inserted single-line images with no spacing (stick to top/bottom)
    * */

--- a/src/textlayout/text_line_impl.cc
+++ b/src/textlayout/text_line_impl.cc
@@ -368,6 +368,53 @@ void TextLineImpl::ApplyAlignment(ParagraphHorizontalAlignment h_align) {
   }
 }
 
+void TextLineImpl::ApplyDominateBaseline() {
+  auto dominate_baseline =
+      paragraph_->GetParagraphStyle().GetDominantBaseline();
+  if (dominate_baseline == DominantBaseline::kAlphabetic) {
+    return;
+  }
+  auto calc_baseline = [](DominantBaseline baseline, float ascent,
+                          float descent) {
+    switch (baseline) {
+      case DominantBaseline::kTop:
+        return 0.f;
+      case DominantBaseline::kMiddle:
+        return 0.5f * (descent - ascent);
+      case DominantBaseline::kHanging:
+        return 0.2f * -ascent;
+      case DominantBaseline::kBottom:
+      case DominantBaseline::kIdeographic:
+        return descent - ascent;
+      default:
+        return -ascent;
+    }
+  };
+  float line_baseline =
+      calc_baseline(dominate_baseline, -max_ascent_, max_descent_);
+  float line_top = GetLineTop() + top_extra_;
+  for (auto& piece : drawer_list_) {
+    auto metrics = piece->GetRun()->GetMetrics();
+    float piece_baseline = calc_baseline(
+        dominate_baseline, metrics.GetMaxAscent(), metrics.GetMaxDescent());
+    float old_piece_baseline = -metrics.GetMaxAscent();
+    float piece_offset_in_line =
+        line_baseline + old_piece_baseline - piece_baseline;
+    piece->SetYOffsetInLine(piece_offset_in_line);
+    if (auto type = piece->GetRun()->GetType();
+        type == RunType::kInlineObject &&
+        piece->GetRun()->GetRunDelegate() != nullptr) {
+      auto delegate = piece->GetRun()->GetRunDelegate();
+      delegate->SetOffset(
+          delegate->GetXOffset(),
+          line_top + piece_offset_in_line + metrics.GetMaxAscent());
+    }
+  }
+  float line_height = GetLineHeight();
+  max_ascent_ = line_baseline;
+  max_descent_ = line_height - line_baseline;
+}
+
 void TextLineImpl::ClearForRelayout() {
   range_lst_.clear();
   empty_ = true;
@@ -485,11 +532,31 @@ void TextLineImpl::GetBoundingRectByCharRange(float bounding_rect[4],
   start_char_pos = std::max(start_char_pos, GetStartCharPos());
   end_char_pos = std::min(end_char_pos, GetEndCharPos());
   TTASSERT(start_char_pos <= end_char_pos);
-  float left = drawer_list_[0]->GetXOffset(), top = GetLineBottom(),
-        right = left, bottom = line_top_;
+  float left = 0;
+  float top = 0;
+  float right = 0;
+  float bottom = 0;
+  GetCharRangeBounds(start_char_pos, end_char_pos, false, &left, &top, &right,
+                     &bottom);
+  *left_p = left;
+  *top_p = top;
+  *width_p = std::max(0.f, right - left);
+  *height_p = std::max(0.f, bottom - top);
+}
+
+void TextLineImpl::GetCharRangeBounds(CharPos start_char_pos,
+                                      CharPos end_char_pos, bool tight,
+                                      float* left, float* top, float* right,
+                                      float* bottom) const {
+  float y_base = tight ? 0.f : line_top_;
+  float local_left = drawer_list_[0]->GetXOffset();
+  float local_top = y_base + GetLineHeight();
+  float local_right = local_left;
+  float local_bottom = y_base;
   enum SearchStatus : uint8_t { kNotStart, kInProgress, kEnd };
   SearchStatus status = kNotStart;
   auto iter = drawer_list_.begin();
+  float tight_bound[4];
   while (iter != drawer_list_.end()) {
     auto& drawer = *iter++;
     if (drawer->GetRun()->IsGhostRun()) {
@@ -499,27 +566,55 @@ void TextLineImpl::GetBoundingRectByCharRange(float bounding_rect[4],
       if (drawer->GetStartCharPosInParagraph() <= start_char_pos &&
           start_char_pos < drawer->GetEndCharPosInParagraph()) {
         status = kInProgress;
-        left = drawer->GetXOffset();
-        left +=
+        local_left = drawer->GetXOffset();
+        local_left +=
             start_char_pos == drawer->GetStartCharPosInParagraph()
                 ? 0
                 : drawer->GetWidthInRange(
                       0, start_char_pos - drawer->GetStartCharPosInParagraph());
+        if (tight) {
+          GetDrawerPieceCharTightBoundRect(drawer.get(), start_char_pos,
+                                           start_char_pos + 1, tight_bound);
+          local_left += tight_bound[0];
+        }
       }
     }
     if (status == kInProgress) {
-      auto metrics = drawer->GetRun()->GetMetrics();
-      top = std::min(
-          top, drawer->GetYOffsetInLine() + metrics.GetMaxAscent() + line_top_);
-      bottom = std::max(bottom, drawer->GetYOffsetInLine() +
-                                    metrics.GetMaxDescent() + line_top_);
+      if (tight) {
+        GetDrawerPieceCharTightBoundRect(drawer.get(), start_char_pos,
+                                         end_char_pos, tight_bound);
+        local_top = std::min(
+            local_top, y_base + drawer->GetYOffsetInLine() + tight_bound[1]);
+        local_bottom = std::max(
+            local_bottom, y_base + drawer->GetYOffsetInLine() + tight_bound[3]);
+      } else {
+        auto metrics = drawer->GetRun()->GetMetrics();
+        local_top = std::min(local_top, y_base + drawer->GetYOffsetInLine() +
+                                            metrics.GetMaxAscent());
+        local_bottom =
+            std::max(local_bottom, y_base + drawer->GetYOffsetInLine() +
+                                       metrics.GetMaxDescent());
+      }
       if (drawer->GetStartCharPosInParagraph() < end_char_pos &&
           end_char_pos <= drawer->GetEndCharPosInParagraph()) {
-        right = drawer->GetXOffset() +
-                drawer->GetWidthInRange(
-                    0, std::min(drawer->GetCharCount(),
-                                end_char_pos -
-                                    drawer->GetStartCharPosInParagraph()));
+        if (tight) {
+          local_right =
+              drawer->GetXOffset() +
+              drawer->GetWidthInRange(
+                  0, std::min(drawer->GetCharCount(),
+                              end_char_pos -
+                                  drawer->GetStartCharPosInParagraph() - 1));
+          GetDrawerPieceCharTightBoundRect(drawer.get(), end_char_pos - 1,
+                                           end_char_pos, tight_bound);
+          local_right += tight_bound[2];
+        } else {
+          local_right =
+              drawer->GetXOffset() +
+              drawer->GetWidthInRange(
+                  0, std::min(
+                         drawer->GetCharCount(),
+                         end_char_pos - drawer->GetStartCharPosInParagraph()));
+        }
         status = kEnd;
       }
     }
@@ -528,18 +623,128 @@ void TextLineImpl::GetBoundingRectByCharRange(float bounding_rect[4],
     }
   }
   if (status != kEnd && !drawer_list_.empty()) {
-    const auto* drawer = drawer_list_.back().get();
-    right =
-        drawer->GetXOffset() +
-        drawer->GetWidthInRange(
-            0, std::min(drawer->GetCharCount(),
-                        end_char_pos - drawer->GetStartCharPosInParagraph()));
+    auto* drawer = drawer_list_.back().get();
+    if (tight) {
+      local_right =
+          drawer->GetXOffset() +
+          drawer->GetWidthInRange(
+              0, std::min(
+                     drawer->GetCharCount(),
+                     end_char_pos - drawer->GetStartCharPosInParagraph() - 1));
+      GetDrawerPieceCharTightBoundRect(drawer, end_char_pos - 1, end_char_pos,
+                                       tight_bound);
+      local_right += tight_bound[2];
+    } else {
+      local_right =
+          drawer->GetXOffset() +
+          drawer->GetWidthInRange(
+              0, std::min(drawer->GetCharCount(),
+                          end_char_pos - drawer->GetStartCharPosInParagraph()));
+    }
   }
-  *left_p = left;
-  *top_p = top;
-  *width_p = std::max(0.f, right - left);
-  *height_p = std::max(0.f, bottom - top);
+  *left = local_left;
+  *top = local_top;
+  *right = local_right;
+  *bottom = local_bottom;
 }
+
+void TextLineImpl::GetTightBoundingRectByCharRange(float bounding_rect[4],
+                                                   CharPos start_char_pos,
+                                                   CharPos end_char_pos) const {
+  if (drawer_list_.empty() || start_char_pos >= end_char_pos ||
+      start_char_pos >= GetEndCharPos() || end_char_pos <= GetStartCharPos()) {
+    bounding_rect[0] = 0;
+    bounding_rect[1] = 0;
+    bounding_rect[2] = 0;
+    bounding_rect[3] = 0;
+    return;
+  }
+  start_char_pos = std::max(start_char_pos, GetStartCharPos());
+  end_char_pos = std::min(end_char_pos, GetEndCharPos());
+  TTASSERT(start_char_pos <= end_char_pos);
+  float left = 0;
+  float top = 0;
+  float right = 0;
+  float bottom = 0;
+  GetCharRangeBounds(start_char_pos, end_char_pos, true, &left, &top, &right,
+                     &bottom);
+  bounding_rect[0] = left;
+  bounding_rect[1] = top - max_ascent_ - top_extra_;
+  bounding_rect[2] = right;
+  bounding_rect[3] = bottom - max_ascent_ - top_extra_;
+}
+
+void TextLineImpl::GetDrawerPieceCharTightBoundRect(DrawerPiece* piece,
+                                                    CharPos start, CharPos end,
+                                                    float bounds[4]) {
+  auto* piece_run = piece->GetRun();
+  auto piece_char_start = std::max(piece->GetStartCharPosInParagraph(), start) -
+                          piece_run->GetStartCharPos();
+  auto piece_char_end = std::min(piece->GetEndCharPosInParagraph(), end) -
+                        piece_run->GetStartCharPos();
+  auto& shape_result = piece_run->shape_result_;
+  auto char_count = shape_result.CharCount();
+  auto glyph_count = shape_result.GlyphCount();
+  piece_char_start = std::min(piece_char_start, char_count);
+  piece_char_end = std::min(piece_char_end, char_count);
+  if (piece_char_start >= piece_char_end || glyph_count == 0) {
+    bounds[0] = 0;
+    bounds[1] = 0;
+    bounds[2] = 0;
+    bounds[3] = 0;
+    return;
+  }
+
+  auto glyph_start = shape_result.CharToGlyph(piece_char_start);
+  auto glyph_end = shape_result.CharToGlyph(piece_char_end - 1) + 1;
+  glyph_start = std::min(glyph_start, glyph_count);
+  glyph_end = std::min(glyph_end, glyph_count);
+  if (glyph_start >= glyph_end) {
+    bounds[0] = 0;
+    bounds[1] = 0;
+    bounds[2] = 0;
+    bounds[3] = 0;
+    return;
+  }
+  float font_size = piece_run->GetLayoutStyle().GetScaledTextSize();
+  bool started = false;
+  TypefaceRef last_font = shape_result.Font(glyph_start);
+  std::vector<GlyphID> glyphs;
+  glyphs.emplace_back(shape_result.Glyphs(glyph_start));
+  auto MergeBounds = [](bool started, float result_bound[4],
+                        float content_bound[4]) {
+    if (!started) {
+      result_bound[0] = content_bound[0];
+      result_bound[1] = content_bound[1];
+      result_bound[2] = content_bound[2];
+      result_bound[3] = content_bound[3];
+    } else {
+      result_bound[1] = std::min(result_bound[1], content_bound[1]);
+      result_bound[2] = content_bound[2];
+      result_bound[3] = std::max(result_bound[3], content_bound[3]);
+    }
+  };
+  float content_bound[4];
+  for (auto index = glyph_start + 1; index < glyph_end; index++) {
+    auto& current_font = shape_result.Font(index);
+    if (current_font != last_font) {
+      last_font->GetWidthBounds(content_bound, glyphs.data(),
+                                static_cast<uint32_t>(glyphs.size()),
+                                font_size);
+      MergeBounds(started, bounds, content_bound);
+      started = true;
+      last_font = current_font;
+      glyphs.clear();
+    }
+    glyphs.emplace_back(shape_result.Glyphs(index));
+  }
+  if (!glyphs.empty()) {
+    last_font->GetWidthBounds(content_bound, glyphs.data(),
+                              static_cast<uint32_t>(glyphs.size()), font_size);
+    MergeBounds(started, bounds, content_bound);
+  }
+}
+
 uint32_t TextLineImpl::GetCharPosByCoordinateX(float x) const {
   RunRange* prev_drawer = nullptr;
   float prev_right = 0;

--- a/src/textlayout/text_line_impl.h
+++ b/src/textlayout/text_line_impl.h
@@ -36,6 +36,20 @@ class TextLineImpl : public TextLine {
   void CreateDrawerPiece();
   void TrimTailSpace();
   void InsertDrawerPiece(std::unique_ptr<DrawerPiece> drawer_piece);
+  void GetCharRangeBounds(CharPos start_char_pos, CharPos end_char_pos,
+                          bool tight, float* left, float* top, float* right,
+                          float* bottom) const;
+  /**
+   *
+   * @param piece drawer piece
+   * @param start char start in para
+   * @param end char end in para
+   * @param bounds [first glyph bounding left, max ascent, last glyph bounding
+   * right, max descent]
+   */
+  static void GetDrawerPieceCharTightBoundRect(DrawerPiece* piece,
+                                               CharPos start, CharPos end,
+                                               float bounds[4]);
 
  public:
   LayoutPosition UpdateLine(LayoutPosition pos, float max_ascent,
@@ -66,6 +80,7 @@ class TextLineImpl : public TextLine {
   void UpdateXMax(float width) override;
   void ApplyAlignment() override;
   void ApplyAlignment(ParagraphHorizontalAlignment h_align);
+  void ApplyDominateBaseline();
   void ModifyHorizontalAlignment(ParagraphHorizontalAlignment h_align) override;
   bool StripContentByWidth(float space);
   void AppendGhostRun(std::unique_ptr<BaseRun> ghost_run);
@@ -75,6 +90,9 @@ class TextLineImpl : public TextLine {
   void GetBoundingRectByCharRange(float bounding_rect[4],
                                   CharPos start_char_pos,
                                   CharPos end_char_pos) const override;
+  void GetTightBoundingRectByCharRange(float bounding_rect[4],
+                                       CharPos start_char_pos,
+                                       CharPos end_char_pos) const override;
   CharPos GetCharPosByCoordinateX(float x) const override;
 
  private:

--- a/test/text_layout_test.cc
+++ b/test/text_layout_test.cc
@@ -8,7 +8,9 @@
 #include <textra/tttext_context.h>
 
 #include <cstdint>
+#include <limits>
 #include <memory>
+#include <tuple>
 #include <utility>
 
 #include "mocks.h"
@@ -37,24 +39,47 @@ class MockInlineObject : public RunDelegate {
 
 class TextLayoutTest : public ::testing::Test {
  public:
-  std::unique_ptr<MockTTShaper> GetFixedSizeMockShaper() {
-    // FontInfo always returns -0.75 ascent and 0.25 descent, multiplied by
-    // font_size
+  ::TypefaceRef CreateFixedSizeMockTypeface() {
     auto mock_typeface = std::make_shared<NiceMock<MockTypefaceHelper>>();
     testing::Mock::AllowLeak(mock_typeface.get());
     ON_CALL(*mock_typeface, OnCreateFontInfo(_, _))
         .WillByDefault(Invoke([](FontInfo* info, float font_size) {
           *info = FontInfo(-0.75 * font_size, 0.25 * font_size, font_size);
         }));
+    ON_CALL(*mock_typeface, GetWidthBounds(_, _, _, _))
+        .WillByDefault(Invoke([](float* rect_ltrb, GlyphID[],
+                                 uint32_t glyph_count, float font_size) {
+          if (glyph_count == 0) {
+            rect_ltrb[0] = 0.f;
+            rect_ltrb[1] = 0.f;
+            rect_ltrb[2] = 0.f;
+            rect_ltrb[3] = 0.f;
+            return;
+          }
+          rect_ltrb[0] = 0.f;
+          rect_ltrb[1] = -0.75f * font_size;
+          rect_ltrb[2] = font_size * static_cast<float>(glyph_count);
+          rect_ltrb[3] = 0.25f * font_size;
+        }));
+    ON_CALL(*mock_typeface, GetWidthBound(_, _, _))
+        .WillByDefault(Invoke([](float* rect_ltwh, GlyphID, float font_size) {
+          rect_ltwh[0] = 0.f;
+          rect_ltwh[1] = -0.75f * font_size;
+          rect_ltwh[2] = font_size;
+          rect_ltwh[3] = font_size;
+        }));
+    return mock_typeface;
+  }
 
+  std::unique_ptr<MockTTShaper> CreateFixedSizeMockShaper(
+      const ::TypefaceRef& typeface) {
     auto test_fontmgr = std::make_shared<TestFontMgr>(
-        std::vector<std::shared_ptr<ITypefaceHelper>>{mock_typeface});
+        std::vector<std::shared_ptr<ITypefaceHelper>>{typeface});
     auto mock_shaper = std::make_unique<NiceMock<MockTTShaper>>(
         FontmgrCollection{test_fontmgr});
     ON_CALL(*mock_shaper, OnShapeText(_, _))
         .WillByDefault(
-            Invoke([mock_typeface](const ShapeKey& key, ShapeResult* result) {
-              // Each character takes a fixed space (font_size x font_size)
+            Invoke([typeface](const ShapeKey& key, ShapeResult* result) {
               const size_t char_count = key.text_.size();
               TestShapingResultReader reader(char_count);
               for (size_t i = 0; i < char_count; ++i) {
@@ -62,17 +87,21 @@ class TextLayoutTest : public ::testing::Test {
                 const float font_size = key.style_.GetFontSize();
                 reader.advances_[i] = {font_size, font_size};
               }
-              reader.font_ = mock_typeface;
+              reader.font_ = typeface;
               result->AppendPlatformShapingResult(reader);
             }));
     return mock_shaper;
   }
 
+  std::unique_ptr<MockTTShaper> GetFixedSizeMockShaper() {
+    return CreateFixedSizeMockShaper(CreateFixedSizeMockTypeface());
+  }
+
   // A helper method to set up a Paragraph with the specified content and lay it
   // out in LayoutRegions (with the specified with/height and modes), and
   // returns the layout results.
-  std::pair<std::vector<LayoutResult>,
-            std::vector<std::unique_ptr<LayoutRegion>>>
+  std::tuple<std::unique_ptr<ParagraphImpl>, std::vector<LayoutResult>,
+             std::vector<std::unique_ptr<LayoutRegion>>>
   LayoutContentWithRegionParams(float width, float height,
                                 LayoutMode width_mode, LayoutMode height_mode,
                                 const std::string& content) {
@@ -95,7 +124,8 @@ class TextLayoutTest : public ::testing::Test {
       regions.push_back(std::move(new_region));
       context.SetLayoutBottom(0);
     }
-    return std::make_pair(std::move(results), std::move(regions));
+    return std::make_tuple(std::move(para), std::move(results),
+                           std::move(regions));
   };
 };
 
@@ -106,7 +136,7 @@ TEST_F(TextLayoutTest, DifferentLayoutModes) {
     // AtMost mode
     {
       // 2 chars -> dimension 2 x 1
-      auto [results, regions] = LayoutContentWithRegionParams(
+      auto [para, results, regions] = LayoutContentWithRegionParams(
           page_width, page_height, LayoutMode::kAtMost, LayoutMode::kAtMost,
           "01");
       EXPECT_EQ(results.size(), 1u);
@@ -118,7 +148,7 @@ TEST_F(TextLayoutTest, DifferentLayoutModes) {
     }
     {
       // 5 chars -> dimension 3 x 2
-      auto [results, regions] = LayoutContentWithRegionParams(
+      auto [para, results, regions] = LayoutContentWithRegionParams(
           page_width, page_height, LayoutMode::kAtMost, LayoutMode::kAtMost,
           "01234");
       EXPECT_EQ(results.size(), 1u);
@@ -133,7 +163,7 @@ TEST_F(TextLayoutTest, DifferentLayoutModes) {
     // Definite mode
     {
       // 2 chars -> 1 page, 1 lines
-      auto [results, regions] = LayoutContentWithRegionParams(
+      auto [para, results, regions] = LayoutContentWithRegionParams(
           page_width, page_height, LayoutMode::kDefinite, LayoutMode::kDefinite,
           "01");
       EXPECT_EQ(results.size(), 1u);
@@ -143,7 +173,7 @@ TEST_F(TextLayoutTest, DifferentLayoutModes) {
     }
     {
       // 5 chars -> 1 page, 2 lines
-      auto [results, regions] = LayoutContentWithRegionParams(
+      auto [para, results, regions] = LayoutContentWithRegionParams(
           page_width, page_height, LayoutMode::kDefinite, LayoutMode::kDefinite,
           "01234");
       EXPECT_EQ(results.size(), 1u);
@@ -153,7 +183,7 @@ TEST_F(TextLayoutTest, DifferentLayoutModes) {
     }
     {
       // 10 chars -> 2 regions, 6 chars on first page and 4 chars on second page
-      auto [results, regions] = LayoutContentWithRegionParams(
+      auto [para, results, regions] = LayoutContentWithRegionParams(
           page_width, page_height, LayoutMode::kDefinite, LayoutMode::kDefinite,
           "0123456789");
       EXPECT_EQ(results.size(), 2u);
@@ -177,6 +207,43 @@ TEST_F(TextLayoutTest, ParagraphStyle_DefaultStyle) {
   para_style.SetDefaultStyle(style);
   EXPECT_EQ(para_style.GetDefaultStyle().GetTextSize(), text_size);
   EXPECT_EQ(para_style.GetDefaultStyle().GetForegroundColor(), text_color);
+}
+
+TEST_F(TextLayoutTest, DominantBaselineTopAlignsSmallerRun) {
+  const auto layout_helper = [this](DominantBaseline baseline) {
+    TextLayout layout(GetFixedSizeMockShaper());
+    TTTextContext context;
+    auto para = std::make_unique<ParagraphImpl>();
+    ParagraphStyle para_style;
+    Style default_style;
+    default_style.SetTextSize(10.f);
+    para_style.SetDefaultStyle(default_style);
+    para_style.SetDominantBaseline(baseline);
+    para->SetParagraphStyle(&para_style);
+    Style large;
+    large.SetTextSize(10.f);
+    Style small;
+    small.SetTextSize(5.f);
+    para->AddTextRun(&large, "A");
+    para->AddTextRun(&small, "B");
+    auto region = std::make_unique<LayoutRegion>(100.f, 50.f);
+    layout.Layout(para.get(), region.get(), context);
+    return std::make_pair(std::move(para), std::move(region));
+  };
+
+  auto [para_default, region_default] =
+      layout_helper(DominantBaseline::kAlphabetic);
+  auto* line_default = region_default->GetLine(0);
+  float rect_default[4]{};
+  line_default->GetBoundingRectByCharRange(rect_default, 1, 2);
+
+  auto [para_top, region_top] = layout_helper(DominantBaseline::kTop);
+  auto* line_top = region_top->GetLine(0);
+  float rect_top[4]{};
+  line_top->GetBoundingRectByCharRange(rect_top, 1, 2);
+
+  EXPECT_GT(rect_default[1], line_default->GetLineTop());
+  EXPECT_FLOAT_EQ(rect_top[1], line_top->GetLineTop());
 }
 
 TEST_F(TextLayoutTest, ParagraphStyle_HorizontalAlignment) {
@@ -663,6 +730,255 @@ TEST_F(TextLayoutTest, ParagraphStyle_OverflowWrap) {
     }
   }
 }
+
+TEST_F(TextLayoutTest, TextLine_GetTightBoundingRectByCharRange_GlyphBounds) {
+  TextLayout layout(GetFixedSizeMockShaper());
+  TTTextContext context;
+  auto para = std::make_unique<ParagraphImpl>();
+  Style style;
+  style.SetTextSize(2.f);
+  para->AddTextRun(&style, "ab");
+  auto region = std::make_unique<LayoutRegion>(100.f, 50.f);
+  layout.Layout(para.get(), region.get(), context);
+
+  ASSERT_EQ(region->GetLineCount(), 1u);
+  auto* line = region->GetLine(0);
+  ASSERT_NE(line, nullptr);
+
+  float rect[4]{};
+  line->GetTightBoundingRectByCharRange(rect, 0, 2);
+  EXPECT_FLOAT_EQ(rect[0], 0.f);
+  EXPECT_FLOAT_EQ(rect[1], -1.5f);
+  EXPECT_FLOAT_EQ(rect[2], 4.f);
+  EXPECT_FLOAT_EQ(rect[3], 0.5f);
+
+  line->GetTightBoundingRectByCharRange(rect, 1, 1);
+  EXPECT_FLOAT_EQ(rect[0], 0.f);
+  EXPECT_FLOAT_EQ(rect[1], 0.f);
+  EXPECT_FLOAT_EQ(rect[2], 0.f);
+  EXPECT_FLOAT_EQ(rect[3], 0.f);
+}
+
+TEST_F(TextLayoutTest,
+       TextLine_GetTightBoundingRectByCharRange_LineHeightModes_Consistent) {
+  enum class Mode {
+    kDefault,
+    kExactLarge,
+    kExactSmall,
+    kAtLeastLarge,
+    kAtLeastSmall,
+    kPercentLarge,
+    kPercentSmall,
+  };
+
+  auto layout_helper = [this](Mode mode) {
+    TextLayout layout(GetFixedSizeMockShaper());
+    TTTextContext context;
+    auto para = std::make_unique<ParagraphImpl>();
+    ParagraphStyle para_style;
+    Style style;
+    style.SetTextSize(2.f);
+    para_style.SetDefaultStyle(style);
+    switch (mode) {
+      case Mode::kDefault:
+        break;
+      case Mode::kExactLarge:
+        para_style.SetLineHeightInPxExact(20.f);
+        break;
+      case Mode::kExactSmall:
+        para_style.SetLineHeightInPxExact(1.f);
+        break;
+      case Mode::kAtLeastLarge:
+        para_style.SetLineHeightInPxAtLeast(20.f);
+        break;
+      case Mode::kAtLeastSmall:
+        para_style.SetLineHeightInPxAtLeast(1.f);
+        break;
+      case Mode::kPercentLarge:
+        para_style.SetLineHeightInPercent(1.5f);
+        break;
+      case Mode::kPercentSmall:
+        para_style.SetLineHeightInPercent(0.5f);
+        break;
+    }
+    para->SetParagraphStyle(&para_style);
+    para->AddTextRun(&style, "ab");
+    auto region = std::make_unique<LayoutRegion>(100.f, 50.f);
+    layout.Layout(para.get(), region.get(), context);
+    return std::make_pair(std::move(para), std::move(region));
+  };
+
+  auto [para_default, region_default] = layout_helper(Mode::kDefault);
+  ASSERT_EQ(region_default->GetLineCount(), 1u);
+  auto* line_default = region_default->GetLine(0);
+  ASSERT_NE(line_default, nullptr);
+
+  float rect_default_02[4]{};
+  float rect_default_11[4]{};
+  line_default->GetTightBoundingRectByCharRange(rect_default_02, 0, 2);
+  line_default->GetTightBoundingRectByCharRange(rect_default_11, 1, 1);
+
+  const Mode modes[] = {
+      Mode::kExactLarge,   Mode::kExactSmall,   Mode::kAtLeastLarge,
+      Mode::kAtLeastSmall, Mode::kPercentLarge, Mode::kPercentSmall,
+  };
+  for (auto mode : modes) {
+    auto [para, region] = layout_helper(mode);
+    ASSERT_EQ(region->GetLineCount(), 1u);
+    auto* line = region->GetLine(0);
+    ASSERT_NE(line, nullptr);
+
+    float rect_02[4]{};
+    float rect_11[4]{};
+    line->GetTightBoundingRectByCharRange(rect_02, 0, 2);
+    line->GetTightBoundingRectByCharRange(rect_11, 1, 1);
+    for (int i = 0; i < 4; ++i) {
+      EXPECT_FLOAT_EQ(rect_default_02[i], rect_02[i]);
+      EXPECT_FLOAT_EQ(rect_default_11[i], rect_11[i]);
+    }
+  }
+}
+
+TEST_F(TextLayoutTest,
+       TextLine_GetTightBoundingRectByCharRange_DominantBaselineTop) {
+  TextLayout layout(GetFixedSizeMockShaper());
+  TTTextContext context;
+  auto para = std::make_unique<ParagraphImpl>();
+  ParagraphStyle para_style;
+  Style style;
+  style.SetTextSize(2.f);
+  para_style.SetDefaultStyle(style);
+  para_style.SetDominantBaseline(DominantBaseline::kTop);
+  para->SetParagraphStyle(&para_style);
+  para->AddTextRun(&style, "ab");
+  auto region = std::make_unique<LayoutRegion>(100.f, 50.f);
+  layout.Layout(para.get(), region.get(), context);
+
+  ASSERT_EQ(region->GetLineCount(), 1u);
+  auto* line = region->GetLine(0);
+  ASSERT_NE(line, nullptr);
+  EXPECT_FLOAT_EQ(line->GetLineBaseLine(), line->GetLineTop());
+
+  float rect[4]{};
+  line->GetTightBoundingRectByCharRange(rect, 0, 2);
+  EXPECT_FLOAT_EQ(rect[0], 0.f);
+  EXPECT_FLOAT_EQ(rect[1], 0.f);
+  EXPECT_FLOAT_EQ(rect[2], 4.f);
+  EXPECT_FLOAT_EQ(rect[3], 2.f);
+}
+
+TEST_F(TextLayoutTest,
+       TextLine_GetTightBoundingRectByCharRange_MixedFontSizes_MiddleBaseline) {
+  TextLayout layout(GetFixedSizeMockShaper());
+  TTTextContext context;
+  auto para = std::make_unique<ParagraphImpl>();
+  ParagraphStyle para_style;
+  Style large;
+  large.SetTextSize(10.f);
+  Style small;
+  small.SetTextSize(5.f);
+  para_style.SetDefaultStyle(large);
+  para_style.SetDominantBaseline(DominantBaseline::kMiddle);
+  para->SetParagraphStyle(&para_style);
+  para->AddTextRun(&large, "A");
+  para->AddTextRun(&small, "B");
+  auto region = std::make_unique<LayoutRegion>(100.f, 50.f);
+  layout.Layout(para.get(), region.get(), context);
+
+  ASSERT_EQ(region->GetLineCount(), 1u);
+  auto* line = region->GetLine(0);
+  ASSERT_NE(line, nullptr);
+
+  float rect_large[4]{};
+  line->GetTightBoundingRectByCharRange(rect_large, 0, 1);
+  EXPECT_FLOAT_EQ(rect_large[0], 0.f);
+  EXPECT_FLOAT_EQ(rect_large[1], -5.f);
+  EXPECT_FLOAT_EQ(rect_large[2], 10.f);
+  EXPECT_FLOAT_EQ(rect_large[3], 5.f);
+
+  float rect_small[4]{};
+  line->GetTightBoundingRectByCharRange(rect_small, 1, 2);
+  EXPECT_FLOAT_EQ(rect_small[0], 10.f);
+  EXPECT_FLOAT_EQ(rect_small[1], -2.5f);
+  EXPECT_FLOAT_EQ(rect_small[2], 15.f);
+  EXPECT_FLOAT_EQ(rect_small[3], 2.5f);
+}
+
+TEST_F(TextLayoutTest,
+       TextLine_GetTightBoundingRectByCharRange_MixedFontSizes_TopBaseline) {
+  TextLayout layout(GetFixedSizeMockShaper());
+  TTTextContext context;
+  auto para = std::make_unique<ParagraphImpl>();
+  ParagraphStyle para_style;
+  Style large;
+  large.SetTextSize(10.f);
+  Style small;
+  small.SetTextSize(5.f);
+  para_style.SetDefaultStyle(large);
+  para_style.SetDominantBaseline(DominantBaseline::kTop);
+  para->SetParagraphStyle(&para_style);
+  para->AddTextRun(&large, "A");
+  para->AddTextRun(&small, "B");
+  auto region = std::make_unique<LayoutRegion>(100.f, 50.f);
+  layout.Layout(para.get(), region.get(), context);
+
+  ASSERT_EQ(region->GetLineCount(), 1u);
+  auto* line = region->GetLine(0);
+  ASSERT_NE(line, nullptr);
+
+  float rect_large[4]{};
+  line->GetTightBoundingRectByCharRange(rect_large, 0, 1);
+  EXPECT_FLOAT_EQ(rect_large[0], 0.f);
+  EXPECT_FLOAT_EQ(rect_large[1], 0.f);
+  EXPECT_FLOAT_EQ(rect_large[2], 10.f);
+  EXPECT_FLOAT_EQ(rect_large[3], 10.f);
+
+  float rect_small[4]{};
+  line->GetTightBoundingRectByCharRange(rect_small, 1, 2);
+  EXPECT_FLOAT_EQ(rect_small[0], 10.f);
+  EXPECT_FLOAT_EQ(rect_small[1], 0.f);
+  EXPECT_FLOAT_EQ(rect_small[2], 15.f);
+  EXPECT_FLOAT_EQ(rect_small[3], 5.f);
+}
+
+TEST_F(
+    TextLayoutTest,
+    TextLine_GetTightBoundingRectByCharRange_MixedFontSizes_AlphabeticBaseline) {
+  TextLayout layout(GetFixedSizeMockShaper());
+  TTTextContext context;
+  auto para = std::make_unique<ParagraphImpl>();
+  ParagraphStyle para_style;
+  Style large;
+  large.SetTextSize(10.f);
+  Style small;
+  small.SetTextSize(5.f);
+  para_style.SetDefaultStyle(large);
+  para_style.SetDominantBaseline(DominantBaseline::kAlphabetic);
+  para->SetParagraphStyle(&para_style);
+  para->AddTextRun(&large, "A");
+  para->AddTextRun(&small, "B");
+  auto region = std::make_unique<LayoutRegion>(100.f, 50.f);
+  layout.Layout(para.get(), region.get(), context);
+
+  ASSERT_EQ(region->GetLineCount(), 1u);
+  auto* line = region->GetLine(0);
+  ASSERT_NE(line, nullptr);
+
+  float rect_large[4]{};
+  line->GetTightBoundingRectByCharRange(rect_large, 0, 1);
+  EXPECT_FLOAT_EQ(rect_large[0], 0.f);
+  EXPECT_FLOAT_EQ(rect_large[1], -7.5f);
+  EXPECT_FLOAT_EQ(rect_large[2], 10.f);
+  EXPECT_FLOAT_EQ(rect_large[3], 2.5f);
+
+  float rect_small[4]{};
+  line->GetTightBoundingRectByCharRange(rect_small, 1, 2);
+  EXPECT_FLOAT_EQ(rect_small[0], 10.f);
+  EXPECT_FLOAT_EQ(rect_small[1], -3.75f);
+  EXPECT_FLOAT_EQ(rect_small[2], 15.f);
+  EXPECT_FLOAT_EQ(rect_small[3], 1.25f);
+}
+
 TEST_F(TextLayoutTest, InlineObjectWithBaselineOffset) {
   const float page_width = 100.0f;
   const float page_height = 100.0f;


### PR DESCRIPTION
Add DominantBaseline to adjust line baseline placement and align runs within a line. Expose TextLine::GetTightBoundingRectByCharRange() for precise char-range metrics, and add tests for dominant baseline and mixed font sizes. Update ParagraphStyle docs.