### PR TITLE
[BugFix] enable CoreText shaper in release builds

### DIFF
--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -18,7 +18,7 @@ declare_args() {
   prj_root = rebase_path("..")
   enable_javashaper = is_android && !is_lvgl
   enable_skshaper = is_android || is_mac || is_harmony || is_win || is_linux
-  enable_ctshaper = (is_ios || is_mac) && is_lvgl
+  enable_ctshaper = (is_ios || is_mac) && !is_lvgl
   enable_harmony = is_harmony
   enable_minikin = false
   enable_lvglshaper = is_lvgl


### PR DESCRIPTION
Correct the GN ctshaper condition for non-LVGL iOS/macOS builds. This restores ENABLE_CTSHAPER and CoreText shaper sources in the generated podspec, so CreateShaper(kSystem) no longer returns null in released xcframework binaries.