### PR TITLE
[BugFix] use font em-height for dominant baseline alignment

### DIFF
--- a/LynxTextra.podspec
+++ b/LynxTextra.podspec
@@ -109,6 +109,8 @@ Pod::Spec.new do |s|
                                 "src/ports/shaper/coretext/shaper_core_text.mm",
                                 "src/textlayout/font_info.cc",
                                 "src/textlayout/fontmgr_collection.cc",
+                                "src/textlayout/dominate_baseline.cc",
+                                "src/textlayout/dominate_baseline.h",
                                 "src/textlayout/internal/boundary_analyst.cc",
                                 "src/textlayout/internal/boundary_analyst.h",
                                 "src/textlayout/internal/line_range.h",
@@ -172,4 +174,3 @@ Pod::Spec.new do |s|
 
   end
 end
-

--- a/public/textra/font_info.h
+++ b/public/textra/font_info.h
@@ -179,6 +179,26 @@ class L_EXPORT FontInfo {
 
   float font_size_ = 0;
 };
+
+/**
+ * @brief Holds em-height ascent/descent values for a given font size.
+ */
+class L_EXPORT FontEmHeight {
+ public:
+  FontEmHeight() : FontEmHeight(0, 0) {}
+  FontEmHeight(float ascent, float descent)
+      : ascent_(ascent), descent_(descent) {}
+  ~FontEmHeight() = default;
+
+  float GetAscent() const { return ascent_; }
+  void SetAscent(float ascent) { ascent_ = ascent; }
+  float GetDescent() const { return descent_; }
+  void SetDescent(float descent) { descent_ = descent; }
+
+ private:
+  float ascent_ = 0;
+  float descent_ = 0;
+};
 }  // namespace tttext
 }  // namespace ttoffice
 #endif  // PUBLIC_TEXTRA_FONT_INFO_H_

--- a/public/textra/i_typeface_helper.h
+++ b/public/textra/i_typeface_helper.h
@@ -60,6 +60,17 @@ class ITypefaceHelper : public std::enable_shared_from_this<ITypefaceHelper> {
     return info;
   }
 
+  const FontEmHeight& GetFontEmHeight(float font_size) {
+    std::lock_guard<std::mutex> guard(font_em_height_cache_lock_);
+    auto iter = font_em_height_cache_.find(font_size);
+    if (iter != font_em_height_cache_.end()) {
+      return iter->second;
+    }
+    auto& em_height = font_em_height_cache_[font_size];
+    OnCreateFontEmHeight(&em_height, font_size);
+    return em_height;
+  }
+
   virtual uint32_t GetUnitsPerEm() const = 0;
 
   const ttoffice::tttext::FontStyle& FontStyle() const { return font_style_; }
@@ -68,12 +79,21 @@ class ITypefaceHelper : public std::enable_shared_from_this<ITypefaceHelper> {
 
  protected:
   virtual void OnCreateFontInfo(FontInfo* info, float font_size) const = 0;
+  virtual void OnCreateFontEmHeight(FontEmHeight* em_height,
+                                    float font_size) const {
+    FontInfo info;
+    OnCreateFontInfo(&info, font_size);
+    em_height->SetAscent(-info.GetAscent());
+    em_height->SetDescent(info.GetDescent());
+  }
 
   uint32_t unique_id_;
   class FontStyle font_style_;
   std::unordered_map<float, FontInfo> font_info_cache_;
+  std::unordered_map<float, FontEmHeight> font_em_height_cache_;
   std::string font_name_;
   std::mutex font_info_cache_lock_;
+  std::mutex font_em_height_cache_lock_;
 };
 }  // namespace tttext
 }  // namespace ttoffice

--- a/public/textra/platform/skity/skity_font_data.h
+++ b/public/textra/platform/skity/skity_font_data.h
@@ -1,0 +1,108 @@
+// Copyright 2022 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef PUBLIC_TEXTRA_PLATFORM_SKITY_SKITY_FONT_DATA_H_
+#define PUBLIC_TEXTRA_PLATFORM_SKITY_SKITY_FONT_DATA_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <skity/text/font.hpp>
+#include <skity/text/typeface.hpp>
+#include <utility>
+
+namespace skity {
+
+namespace textlayout {
+
+class SkityFontData {
+ public:
+  explicit SkityFontData(std::shared_ptr<Typeface> typeface)
+      : typeface_(std::move(typeface)) {}
+
+  std::shared_ptr<Typeface> GetTypeface() const { return typeface_; }
+
+  std::pair<float, float> GetAscentAndDescent(float text_size) const {
+    EnsureEmHeightCached();
+    uint32_t units_per_em = typeface_ ? typeface_->GetUnitsPerEm() : 0u;
+    if (!has_em_height_ || units_per_em == 0) {
+      return GetFallbackAscentAndDescent(text_size);
+    }
+
+    float scale = text_size / static_cast<float>(units_per_em);
+    return std::make_pair(static_cast<float>(em_height_ascender_) * scale,
+                          static_cast<float>(em_height_descender_) * scale);
+  }
+
+  float GetAscent(float text_size) const {
+    return GetAscentAndDescent(text_size).first;
+  }
+
+  float GetDescent(float text_size) const {
+    return GetAscentAndDescent(text_size).second;
+  }
+
+  bool HasEmHeight() const {
+    EnsureEmHeightCached();
+    return has_em_height_;
+  }
+
+ private:
+  static constexpr FontTableTag SetFourByteTag(char a, char b, char c,
+                                               char d) noexcept {
+    return (static_cast<FontTableTag>(static_cast<uint8_t>(a)) << 24) |
+           (static_cast<FontTableTag>(static_cast<uint8_t>(b)) << 16) |
+           (static_cast<FontTableTag>(static_cast<uint8_t>(c)) << 8) |
+           static_cast<FontTableTag>(static_cast<uint8_t>(d));
+  }
+
+  static constexpr int16_t ByteSwap(int16_t value) noexcept {
+    uint16_t u = static_cast<uint16_t>(value);
+    u = static_cast<uint16_t>((u << 8) | (u >> 8));
+    return static_cast<int16_t>(u);
+  }
+
+  void EnsureEmHeightCached() const {
+    std::call_once(em_height_once_, [this]() {
+      if (!typeface_) {
+        return;
+      }
+
+      int16_t buffer[2] = {0, 0};
+      size_t size = typeface_->GetTableData(SetFourByteTag('O', 'S', '/', '2'),
+                                            68, sizeof(buffer), buffer);
+      if (size != sizeof(buffer)) {
+        return;
+      }
+
+      em_height_ascender_ = ByteSwap(buffer[0]);
+      em_height_descender_ = -ByteSwap(buffer[1]);
+      has_em_height_ = true;
+    });
+  }
+
+  std::pair<float, float> GetFallbackAscentAndDescent(float text_size) const {
+    if (!typeface_) {
+      return std::make_pair(0.f, 0.f);
+    }
+
+    FontMetrics metrics{};
+    Font font(typeface_, text_size);
+    font.GetMetrics(&metrics);
+    return std::make_pair(-metrics.ascent_, metrics.descent_);
+  }
+
+  std::shared_ptr<Typeface> typeface_;
+  mutable std::once_flag em_height_once_;
+  mutable bool has_em_height_ = false;
+  mutable int16_t em_height_ascender_ = 0;
+  mutable int16_t em_height_descender_ = 0;
+};
+
+}  // namespace textlayout
+
+}  // namespace skity
+
+#endif  // PUBLIC_TEXTRA_PLATFORM_SKITY_SKITY_FONT_DATA_H_

--- a/public/textra/platform/skity/skity_typeface_helper.h
+++ b/public/textra/platform/skity/skity_typeface_helper.h
@@ -6,6 +6,7 @@
 #define PUBLIC_TEXTRA_PLATFORM_SKITY_SKITY_TYPEFACE_HELPER_H_
 
 #include <textra/i_typeface_helper.h>
+#include <textra/platform/skity/skity_font_data.h>
 
 #include <memory>
 #include <skity/text/font.hpp>
@@ -17,7 +18,8 @@ class SkityTypefaceHelper : public tttext::ITypefaceHelper {
  public:
   explicit SkityTypefaceHelper(std::shared_ptr<Typeface> typeface)
       : tttext::ITypefaceHelper(typeface->TypefaceId()),
-        typeface_(std::move(typeface)) {
+        typeface_(std::move(typeface)),
+        font_data_(typeface_) {
     skity::FontStyle skity_font_style = typeface_->GetFontStyle();
     font_style_ = tttext::FontStyle(
         static_cast<tttext::Weight>(skity_font_style.weight()),
@@ -99,8 +101,16 @@ class SkityTypefaceHelper : public tttext::ITypefaceHelper {
     info->SetFontSize(font_size);
   }
 
+  void OnCreateFontEmHeight(tttext::FontEmHeight* em_height,
+                            float font_size) const override {
+    auto ascent_descent = font_data_.GetAscentAndDescent(font_size);
+    em_height->SetAscent(ascent_descent.first);
+    em_height->SetDescent(ascent_descent.second);
+  }
+
  private:
   std::shared_ptr<Typeface> typeface_;
+  SkityFontData font_data_;
   // int font_index_; not used for now.
 };
 }  // namespace textlayout

--- a/public/textra/run_delegate.h
+++ b/public/textra/run_delegate.h
@@ -9,6 +9,7 @@
 
 namespace ttoffice {
 namespace tttext {
+class DominateBaselineHelper;
 class TextLineImpl;
 class ICanvasHelper;
 /**
@@ -71,6 +72,7 @@ class RunDelegate {
   float x_offset_{std::numeric_limits<float>::lowest()};
   float y_offset_{std::numeric_limits<float>::lowest()};
   friend class TextLineImpl;
+  friend class DominateBaselineHelper;
 };
 }  // namespace tttext
 }  // namespace ttoffice

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -192,6 +192,8 @@ source_set("textlayout") {
   sources += textlayout_public_headers
   sources += [
     "$prj_root/src/ports/platform_helper.cc",
+    "$prj_root/src/textlayout/dominate_baseline.cc",
+    "$prj_root/src/textlayout/dominate_baseline.h",
     "$prj_root/src/textlayout/font_info.cc",
     "$prj_root/src/textlayout/fontmgr_collection.cc",
     "$prj_root/src/textlayout/internal/boundary_analyst.cc",

--- a/src/textlayout/dominate_baseline.cc
+++ b/src/textlayout/dominate_baseline.cc
@@ -1,0 +1,116 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/textlayout/dominate_baseline.h"
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+#include "src/textlayout/text_line_impl.h"
+
+namespace ttoffice {
+namespace tttext {
+
+float DominateBaselineHelper::CalcBaselineOffset(DominantBaseline baseline,
+                                                 float ascent, float descent) {
+  switch (baseline) {
+    case DominantBaseline::kTop:
+      return 0.f;
+    case DominantBaseline::kMiddle:
+      return 0.5f * (descent - ascent);
+    case DominantBaseline::kHanging:
+      return 0.2f * -ascent;
+    case DominantBaseline::kBottom:
+    case DominantBaseline::kIdeographic:
+      return descent - ascent;
+    default:
+      return -ascent;
+  }
+}
+
+std::pair<float, float> DominateBaselineHelper::CalcRunEmHeight(
+    const BaseRun* run) {
+  auto run_metrics = run->GetMetrics();
+  float run_em_ascent = run_metrics.GetMaxAscent();
+  float run_em_descent = run_metrics.GetMaxDescent();
+  if (!run->shape_result_.Valid()) {
+    return std::make_pair(run_em_ascent, run_em_descent);
+  }
+  float min_em_ascent = 0.f;
+  float max_em_descent = 0.f;
+  bool has_font = false;
+  float font_size = run->GetLayoutStyle().GetTextSize();
+  auto glyph_count = run->shape_result_.GlyphCount();
+  for (uint32_t idx = 0; idx < glyph_count; ++idx) {
+    auto font = run->shape_result_.Font(idx);
+    if (!font) {
+      continue;
+    }
+    has_font = true;
+    auto em = font->GetFontEmHeight(font_size);
+    min_em_ascent = std::min(min_em_ascent, -em.GetAscent());
+    max_em_descent = std::max(max_em_descent, em.GetDescent());
+  }
+  if (has_font) {
+    run_em_ascent = min_em_ascent;
+    run_em_descent = max_em_descent;
+  }
+  return std::make_pair(run_em_ascent, run_em_descent);
+}
+
+void DominateBaselineHelper::ApplyDominateBaseline(TextLineImpl* line) {
+  auto dominate_baseline =
+      line->paragraph_->GetParagraphStyle().GetDominantBaseline();
+  if (dominate_baseline == DominantBaseline::kAlphabetic) {
+    return;
+  }
+  std::vector<std::pair<float, float>> piece_em_heights;
+  piece_em_heights.reserve(line->drawer_list_.size());
+
+  float line_em_ascent = 0.f;
+  float line_em_descent = 0.f;
+  for (auto& piece : line->drawer_list_) {
+    auto run_em = CalcRunEmHeight(piece->GetRun());
+    piece_em_heights.push_back(run_em);
+    line_em_ascent = std::min(line_em_ascent, run_em.first);
+    line_em_descent = std::max(line_em_descent, run_em.second);
+  }
+  if (piece_em_heights.empty()) {
+    line_em_ascent = -line->max_ascent_;
+    line_em_descent = line->max_descent_;
+  }
+
+  float line_baseline =
+      line->max_ascent_ + line_em_ascent +
+      CalcBaselineOffset(dominate_baseline, line_em_ascent, line_em_descent);
+  line_baseline = std::clamp(line_baseline, 0.f, line->GetLineHeight());
+  float line_top = line->GetLineTop() + line->top_extra_;
+  for (size_t piece_idx = 0; piece_idx < line->drawer_list_.size();
+       ++piece_idx) {
+    auto& piece = line->drawer_list_[piece_idx];
+    auto* run = piece->GetRun();
+    auto metrics = run->GetMetrics();
+    auto run_em = piece_em_heights[piece_idx];
+    float piece_baseline =
+        CalcBaselineOffset(dominate_baseline, run_em.first, run_em.second);
+    float old_piece_baseline = -run_em.first;
+    float piece_offset_in_line =
+        line_baseline + old_piece_baseline - piece_baseline;
+    piece->SetYOffsetInLine(piece_offset_in_line);
+    if (auto type = run->GetType();
+        type == RunType::kInlineObject && run->GetRunDelegate() != nullptr) {
+      auto delegate = run->GetRunDelegate();
+      delegate->SetOffset(
+          delegate->GetXOffset(),
+          line_top + piece_offset_in_line + metrics.GetMaxAscent());
+    }
+  }
+  float line_height = line->GetLineHeight();
+  line->max_ascent_ = line_baseline;
+  line->max_descent_ = line_height - line_baseline;
+}
+
+}  // namespace tttext
+}  // namespace ttoffice

--- a/src/textlayout/dominate_baseline.h
+++ b/src/textlayout/dominate_baseline.h
@@ -1,0 +1,29 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_TEXTLAYOUT_DOMINATE_BASELINE_H_
+#define SRC_TEXTLAYOUT_DOMINATE_BASELINE_H_
+
+#include <cstdint>
+#include <utility>
+
+namespace ttoffice {
+namespace tttext {
+enum class DominantBaseline : uint8_t;
+class BaseRun;
+class TextLineImpl;
+
+class DominateBaselineHelper {
+ public:
+  static void ApplyDominateBaseline(TextLineImpl* line);
+
+ private:
+  static float CalcBaselineOffset(DominantBaseline baseline, float ascent,
+                                  float descent);
+  static std::pair<float, float> CalcRunEmHeight(const BaseRun* run);
+};
+}  // namespace tttext
+}  // namespace ttoffice
+
+#endif  // SRC_TEXTLAYOUT_DOMINATE_BASELINE_H_

--- a/src/textlayout/run/base_run.h
+++ b/src/textlayout/run/base_run.h
@@ -35,6 +35,7 @@ class TextAttachment;
 class TTStringPiece;
 class ShapeResult;
 class LayoutMeasurer;
+class DominateBaselineHelper;
 enum class RunType : uint8_t;
 enum class LineBreakType : uint8_t;
 enum class CharacterVerticalAlignment : uint8_t;
@@ -43,6 +44,7 @@ class BaseRun {
   friend ParagraphImpl;
   friend TextLineImpl;
   friend class LayoutDrawer;
+  friend class DominateBaselineHelper;
 
  public:
   static constexpr const char* ObjectReplacementCharacter() {

--- a/src/textlayout/text_line_impl.cc
+++ b/src/textlayout/text_line_impl.cc
@@ -10,6 +10,7 @@
 #include <cassert>
 #include <utility>
 
+#include "src/textlayout/dominate_baseline.h"
 #include "src/textlayout/internal/boundary_analyst.h"
 #include "src/textlayout/internal/line_range.h"
 #include "src/textlayout/internal/run_range.h"
@@ -369,50 +370,7 @@ void TextLineImpl::ApplyAlignment(ParagraphHorizontalAlignment h_align) {
 }
 
 void TextLineImpl::ApplyDominateBaseline() {
-  auto dominate_baseline =
-      paragraph_->GetParagraphStyle().GetDominantBaseline();
-  if (dominate_baseline == DominantBaseline::kAlphabetic) {
-    return;
-  }
-  auto calc_baseline = [](DominantBaseline baseline, float ascent,
-                          float descent) {
-    switch (baseline) {
-      case DominantBaseline::kTop:
-        return 0.f;
-      case DominantBaseline::kMiddle:
-        return 0.5f * (descent - ascent);
-      case DominantBaseline::kHanging:
-        return 0.2f * -ascent;
-      case DominantBaseline::kBottom:
-      case DominantBaseline::kIdeographic:
-        return descent - ascent;
-      default:
-        return -ascent;
-    }
-  };
-  float line_baseline =
-      calc_baseline(dominate_baseline, -max_ascent_, max_descent_);
-  float line_top = GetLineTop() + top_extra_;
-  for (auto& piece : drawer_list_) {
-    auto metrics = piece->GetRun()->GetMetrics();
-    float piece_baseline = calc_baseline(
-        dominate_baseline, metrics.GetMaxAscent(), metrics.GetMaxDescent());
-    float old_piece_baseline = -metrics.GetMaxAscent();
-    float piece_offset_in_line =
-        line_baseline + old_piece_baseline - piece_baseline;
-    piece->SetYOffsetInLine(piece_offset_in_line);
-    if (auto type = piece->GetRun()->GetType();
-        type == RunType::kInlineObject &&
-        piece->GetRun()->GetRunDelegate() != nullptr) {
-      auto delegate = piece->GetRun()->GetRunDelegate();
-      delegate->SetOffset(
-          delegate->GetXOffset(),
-          line_top + piece_offset_in_line + metrics.GetMaxAscent());
-    }
-  }
-  float line_height = GetLineHeight();
-  max_ascent_ = line_baseline;
-  max_descent_ = line_height - line_baseline;
+  DominateBaselineHelper::ApplyDominateBaseline(this);
 }
 
 void TextLineImpl::ClearForRelayout() {

--- a/src/textlayout/text_line_impl.h
+++ b/src/textlayout/text_line_impl.h
@@ -16,6 +16,7 @@
 namespace ttoffice {
 namespace tttext {
 enum class LineType : uint8_t;
+class DominateBaselineHelper;
 using DrawerPiece = RunRange;
 class TextLineImpl : public TextLine {
   friend LayoutRegion;
@@ -23,6 +24,7 @@ class TextLineImpl : public TextLine {
   friend TextLayoutImpl;
   friend LayoutDrawer;
   friend class CompressRowLine;
+  friend class DominateBaselineHelper;
 
  public:
   TextLineImpl() = delete;


### PR DESCRIPTION
- add FontEmHeight and em-height cache in ITypefaceHelper
- add SkityFontData to read OS/2 em-height with metrics fallback
- compute line/piece baseline from run em-height in TextLineImpl