### PR TITLE
[BugFix] fix exclusive-end handling in line decoration drawing

### DIFF
--- a/src/textlayout/layout_drawer.cc
+++ b/src/textlayout/layout_drawer.cc
@@ -109,7 +109,7 @@ void LayoutDrawer::DrawLineBackground(TextLine* i_line,
   auto start_char = char_start_in_para;
   StyleRange range;
   std::array<float, 4> rect{};
-  while (range.GetRange().GetEnd() <= char_end_in_para) {
+  while (start_char < char_end_in_para) {
     style_manager->GetStyleRange(
         &range, start_char,
         Style::BackgroundColorFlag | Style::BackgroundPainterFlag);
@@ -140,7 +140,7 @@ void LayoutDrawer::DrawLineDecoration(TextLine* i_line,
   StyleRange range;
   std::array<float, 4> rect{};
   float line_y = 0;
-  while (range.GetRange().GetEnd() <= char_end_in_para) {
+  while (start_char < char_end_in_para) {
     style_manager->GetStyleRange(&range, start_char, Style::DecorationFlag);
     auto end_char = std::min(range.GetRange().GetEnd(), char_end_in_para);
     auto& decorate_style = range.GetStyle();

--- a/src/textlayout/text_line_impl.cc
+++ b/src/textlayout/text_line_impl.cc
@@ -464,7 +464,7 @@ void TextLineImpl::GetBoundingRectByCharRange(float bounding_rect[4],
   auto* top_p = bounding_rect + 1;
   auto* width_p = bounding_rect + 2;
   auto* height_p = bounding_rect + 3;
-  if (drawer_list_.empty()) {
+  if (drawer_list_.empty() || start_char_pos >= end_char_pos) {
     *left_p = 0;
     *top_p = 0;
     *width_p = 0;

--- a/test/layout_drawer_test.cc
+++ b/test/layout_drawer_test.cc
@@ -107,6 +107,48 @@ TEST(LayoutDrawer, DrawLayoutPage_TextWithUnderline) {
   drawer.DrawLayoutPage(page.get());
 }
 
+TEST(LayoutDrawer, DrawTextLine_ExclusiveEndDoesNotDrawNextDecoration) {
+  // Arrange
+  ParagraphImpl para;
+  Style style;
+  style.SetTextSize(1.f);
+  para.AddTextRun(&style, "AB");
+
+  Style underline_style;
+  underline_style.SetDecorationType(DecorationType::kUnderLine);
+  underline_style.SetDecorationStyle(LineType::kSolid);
+  underline_style.SetDecorationColor(TTColor::BLACK);
+  para.ApplyStyleInRange(underline_style, 1, 1);
+
+  TTTextContext context;
+  auto page = std::make_unique<LayoutRegion>(100.f, 100.f);
+  TextLayout layout(TestUtils::getTestShaper());
+  layout.Layout(&para, page.get(), context);
+
+  ASSERT_EQ(page->GetLineCount(), 1u);
+  TextLine* text_line = page->GetLine(0);
+  ASSERT_NE(text_line, nullptr);
+
+  NiceMock<MockCanvasHelper> canvas_helper;
+  LayoutDrawer drawer(&canvas_helper);
+  ON_CALL(canvas_helper, CreatePainter()).WillByDefault(Invoke([]() {
+    return std::make_unique<Painter>();
+  }));
+
+  // The end position is exclusive, so drawing [0, 1) must not draw the
+  // decoration starting at character 1.
+  EXPECT_CALL(canvas_helper, DrawGlyphs(_, 1, _, nullptr, 0, _, _, _, _, _))
+      .Times(1);
+  EXPECT_CALL(canvas_helper, DrawLine(_, _, _, _, _)).Times(0);
+  drawer.DrawTextLine(text_line, 0, 1);
+  Mock::VerifyAndClearExpectations(&canvas_helper);
+
+  EXPECT_CALL(canvas_helper, DrawGlyphs(_, 2, _, nullptr, 0, _, _, _, _, _))
+      .Times(1);
+  EXPECT_CALL(canvas_helper, DrawLine(_, _, _, _, _)).Times(1);
+  drawer.DrawTextLine(text_line, 0, 2);
+}
+
 TEST(LayoutDrawer, DrawLayoutPage_RunDelegate) {
   // Arrange
   const float width = 100.f;


### PR DESCRIPTION
textlayout uses half-open ranges ([start, end)) for char positions, but DrawLineDecoration() still iterates once more when char_end_in_para is equal to the start of the next decoration range. This makes the style at char_end_in_para get queried and may draw the following decoration unexpectedly.

Add a regression test to verify that DrawTextLine(..., 0, 1) does not draw an underline that starts at char 1, while drawing the full range still renders the underline correctly.