### PR TITLE
[BugFix] Improve justification opportunities for mixed text

### DIFF
--- a/LynxTextra.podspec
+++ b/LynxTextra.podspec
@@ -115,6 +115,8 @@ Pod::Spec.new do |s|
                                 "src/textlayout/dominate_baseline.h",
                                 "src/textlayout/internal/boundary_analyst.cc",
                                 "src/textlayout/internal/boundary_analyst.h",
+                                "src/textlayout/internal/justify_analyst.cc",
+                                "src/textlayout/internal/justify_analyst.h",
                                 "src/textlayout/internal/line_range.h",
                                 "src/textlayout/internal/run_range.h",
                                 "src/textlayout/layout_drawer.cc",

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -199,6 +199,8 @@ source_set("textlayout") {
     "$prj_root/src/textlayout/fontmgr_collection.cc",
     "$prj_root/src/textlayout/internal/boundary_analyst.cc",
     "$prj_root/src/textlayout/internal/boundary_analyst.h",
+    "$prj_root/src/textlayout/internal/justify_analyst.cc",
+    "$prj_root/src/textlayout/internal/justify_analyst.h",
     "$prj_root/src/textlayout/internal/line_range.h",
     "$prj_root/src/textlayout/internal/run_range.h",
     "$prj_root/src/textlayout/layout_drawer.cc",

--- a/src/textlayout/internal/boundary_analyst.h
+++ b/src/textlayout/internal/boundary_analyst.h
@@ -32,7 +32,6 @@ class BoundaryAnalyst {
   void UpgradeBoundaryType(const Range& range, BoundaryType type);
 
  private:
- private:
   std::vector<BoundaryType> boundary_;
 };
 }  // namespace tttext

--- a/src/textlayout/internal/justify_analyst.cc
+++ b/src/textlayout/internal/justify_analyst.cc
@@ -1,0 +1,51 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/textlayout/internal/justify_analyst.h"
+
+#include "src/textlayout/utils/u_8_string.h"
+
+namespace ttoffice {
+namespace tttext {
+
+JustifyAnalyst::JustifyAnalyst(const TTString& content) {
+  const auto char_count = content.GetCharCount();
+  justify_opportunity_.resize(char_count, false);
+  for (auto k = 0u; k + 1 < char_count; ++k) {
+    const auto ch = static_cast<char32_t>(content.GetUnicode(k));
+    const auto next_ch = static_cast<char32_t>(content.GetUnicode(k + 1));
+    justify_opportunity_[k] = CanInsertJustifySpaceAfterChars(ch, next_ch);
+  }
+}
+
+CharPos JustifyAnalyst::FindNextJustifyOpportunity(CharPos start_char) const {
+  for (auto k = start_char; k < justify_opportunity_.size(); ++k) {
+    if (justify_opportunity_[k]) {
+      return k + 1;
+    }
+  }
+  return static_cast<CharPos>(justify_opportunity_.size());
+}
+
+bool JustifyAnalyst::CanInsertJustifySpaceAfter(CharPos char_pos) const {
+  return char_pos < justify_opportunity_.size() &&
+         justify_opportunity_[char_pos];
+}
+
+bool JustifyAnalyst::CanInsertJustifySpaceAfterChars(char32_t ch,
+                                                     char32_t next_ch) {
+  const bool ch_is_word_separator = base::IsWordSeparator(ch);
+  const bool next_is_word_separator = base::IsWordSeparator(next_ch);
+  if (ch_is_word_separator && !next_is_word_separator) {
+    return true;
+  }
+  if (base::IsCJK(ch) || base::IsCJK(next_ch) || base::IsCJKPunctuation(ch) ||
+      base::IsCJKPunctuation(next_ch)) {
+    return true;
+  }
+  return false;
+}
+
+}  // namespace tttext
+}  // namespace ttoffice

--- a/src/textlayout/internal/justify_analyst.h
+++ b/src/textlayout/internal/justify_analyst.h
@@ -1,0 +1,31 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_TEXTLAYOUT_INTERNAL_JUSTIFY_ANALYST_H_
+#define SRC_TEXTLAYOUT_INTERNAL_JUSTIFY_ANALYST_H_
+
+#include <vector>
+
+#include "src/textlayout/utils/tt_string.h"
+
+namespace ttoffice {
+namespace tttext {
+class JustifyAnalyst {
+ public:
+  JustifyAnalyst() = delete;
+  explicit JustifyAnalyst(const TTString& content);
+
+ public:
+  CharPos FindNextJustifyOpportunity(CharPos start_char) const;
+  bool CanInsertJustifySpaceAfter(CharPos char_pos) const;
+
+ private:
+  static bool CanInsertJustifySpaceAfterChars(char32_t ch, char32_t next_ch);
+
+  std::vector<char> justify_opportunity_;
+};
+}  // namespace tttext
+}  // namespace ttoffice
+
+#endif  // SRC_TEXTLAYOUT_INTERNAL_JUSTIFY_ANALYST_H_

--- a/src/textlayout/paragraph_impl.cc
+++ b/src/textlayout/paragraph_impl.cc
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "src/textlayout/internal/boundary_analyst.h"
+#include "src/textlayout/internal/justify_analyst.h"
 #include "src/textlayout/layout_position.h"
 #include "src/textlayout/run/ghost_run.h"
 #include "src/textlayout/run/object_run.h"
@@ -31,6 +32,7 @@ ParagraphImpl::ParagraphImpl()
       formated_(false),
       style_manager_(std::make_unique<StyleManager>()),
       boundary_analyst_(nullptr),
+      justify_analyst_(nullptr),
       shaper_(nullptr) {}
 ParagraphImpl::~ParagraphImpl() = default;
 void ParagraphImpl::AddTextRun(const Style& style, const char* content,
@@ -373,6 +375,19 @@ LayoutPosition ParagraphImpl::FindPrevBoundary(const LayoutPosition& start,
     pos.PrevRun();
   }
   return ret;
+}
+void ParagraphImpl::InitJustifyAnalyst() const {
+  if (justify_analyst_ != nullptr) return;
+  justify_analyst_ = std::make_unique<JustifyAnalyst>(content_);
+}
+CharPos ParagraphImpl::FindNextJustifyOpportunity(CharPos start_char) const {
+  InitJustifyAnalyst();
+  return justify_analyst_->FindNextJustifyOpportunity(start_char);
+}
+
+bool ParagraphImpl::CanInsertJustifySpaceAfter(CharPos char_pos) const {
+  InitJustifyAnalyst();
+  return justify_analyst_->CanInsertJustifySpaceAfter(char_pos);
 }
 BoundaryType ParagraphImpl::GetBoundaryTypeBefore(
     const LayoutPosition& position) const {

--- a/src/textlayout/paragraph_impl.h
+++ b/src/textlayout/paragraph_impl.h
@@ -41,6 +41,7 @@ class TextLine;
 class LayoutRegion;
 class RegionPosition;
 class BoundaryAnalyst;
+class JustifyAnalyst;
 class ShaperSkShaper;
 class FontmgrCollection;
 class TTTextContext;
@@ -141,6 +142,8 @@ class ParagraphImpl : public Paragraph {
                                   const BoundaryType& type) const;
   LayoutPosition FindPrevBoundary(const LayoutPosition& start,
                                   const BoundaryType& type) const;
+  CharPos FindNextJustifyOpportunity(CharPos start_char) const;
+  bool CanInsertJustifySpaceAfter(CharPos char_pos) const;
   BoundaryType GetBoundaryTypeBefore(const LayoutPosition& position) const;
   BoundaryType GetBoundaryType(const LayoutPosition& position) const;
   void SetShaper(TTShaper* shaper) { shaper_ = shaper; }
@@ -157,6 +160,7 @@ class ParagraphImpl : public Paragraph {
     return content_.GetCharCount();
   }
   bool SplitRun(uint32_t idx, uint32_t char_pos_in_run);
+  void InitJustifyAnalyst() const;
 
 #ifdef TTTEXT_DEBUG
   std::u32string GetContentWithGhost() const;
@@ -169,6 +173,7 @@ class ParagraphImpl : public Paragraph {
   TTString content_;
   std::unique_ptr<StyleManager> style_manager_;
   std::unique_ptr<BoundaryAnalyst> boundary_analyst_;
+  mutable std::unique_ptr<JustifyAnalyst> justify_analyst_;
   // even: ltr, odd: rtl
   std::vector<uint8_t> bidi_level_;
   std::vector<uint32_t> visual_map_;

--- a/src/textlayout/text_layout_impl.cc
+++ b/src/textlayout/text_layout_impl.cc
@@ -199,10 +199,14 @@ LayoutPosition TextLayoutImpl::AddBreakableRunsToLine(
     // break at any position.
     bool is_last_line = region->GetLineCount() + 1 >=
                         line->GetParagraph()->GetParagraphStyle().GetMaxLines();
+    auto& style = paragraph.GetParagraphStyle();
+    bool has_ellipsis =
+        !style.GetEllipsis().empty() || style.GetEllipsisDelegate() != nullptr;
     auto line_break_pos =
-        is_last_line ? greedy_break_pos
-                     : paragraph.FindPrevBoundary(greedy_break_pos,
-                                                  BoundaryType::kLineBreakable);
+        is_last_line && has_ellipsis
+            ? greedy_break_pos
+            : paragraph.FindPrevBoundary(greedy_break_pos,
+                                         BoundaryType::kLineBreakable);
     if (line_break_pos < pos) line_break_pos = pos;
     if (line_break_pos > pos) {
       auto d_height = AddWordListToRunRange(range.get(), paragraph, pos,

--- a/src/textlayout/text_line_impl.cc
+++ b/src/textlayout/text_line_impl.cc
@@ -111,8 +111,7 @@ CharPos TextLineImpl::GetStartCharPos() const {
 CharPos TextLineImpl::GetEndCharPos() const {
   return paragraph_->LayoutPositionToCharPos(line_end_pos_);
 }
-void TextLineImpl::SplitToWordDrawer(const LineRange& line_range,
-                                     float word_spacing) {
+void TextLineImpl::SplitToWordDrawer(const LineRange& line_range) {
   for (const auto& run_range : line_range.run_range_lst_) {
     if (run_range->GetRun()->IsGhostRun()) {
       drawer_list_.push_back(std::make_unique<DrawerPiece>(*run_range));
@@ -120,16 +119,16 @@ void TextLineImpl::SplitToWordDrawer(const LineRange& line_range,
       auto* run = run_range->GetRun();
       auto start_char = run_range->GetStartCharPosInParagraph();
       auto end_char = run_range->GetEndCharPosInParagraph();
-      auto next_word_boundary = paragraph_->boundary_analyst_->FindNextBoundary(
-          start_char, BoundaryType::kWord);
-      while (next_word_boundary < end_char) {
+      auto next_justify_opportunity =
+          paragraph_->FindNextJustifyOpportunity(start_char);
+      while (next_justify_opportunity < end_char) {
         auto drawer = std::make_unique<DrawerPiece>(
             run, run_range->GetParent(), start_char - run->GetStartCharPos(),
-            next_word_boundary - run->GetStartCharPos());
+            next_justify_opportunity - run->GetStartCharPos());
         InsertDrawerPiece(std::move(drawer));
-        start_char = next_word_boundary;
-        next_word_boundary = paragraph_->boundary_analyst_->FindNextBoundary(
-            start_char, BoundaryType::kWord);
+        start_char = next_justify_opportunity;
+        next_justify_opportunity =
+            paragraph_->FindNextJustifyOpportunity(start_char);
       }
       if (start_char < end_char) {
         auto drawer = std::make_unique<DrawerPiece>(
@@ -145,7 +144,7 @@ void TextLineImpl::CreateDrawerPiece() {
   auto align = paragraph_->GetParagraphStyle().GetHorizontalAlign();
   for (const auto& line_range : range_lst_) {
     if (align == ParagraphHorizontalAlignment::kJustify) {
-      SplitToWordDrawer(*line_range, 0);
+      SplitToWordDrawer(*line_range);
     } else {
       for (const auto& run_range : line_range->run_range_lst_) {
         auto drawer_piece = std::make_unique<DrawerPiece>(*run_range);

--- a/src/textlayout/text_line_impl.h
+++ b/src/textlayout/text_line_impl.h
@@ -34,7 +34,7 @@ class TextLineImpl : public TextLine {
 
  private:
   void SetRangeLst(const std::vector<std::array<float, 2>>& lst);
-  void SplitToWordDrawer(const LineRange& line_range, float word_spacing);
+  void SplitToWordDrawer(const LineRange& line_range);
   void CreateDrawerPiece();
   void TrimTailSpace();
   void InsertDrawerPiece(std::unique_ptr<DrawerPiece> drawer_piece);

--- a/src/textlayout/utils/u_8_string.h
+++ b/src/textlayout/utils/u_8_string.h
@@ -236,7 +236,10 @@ uint32_t U32IndexToU16(const char32_t* content, uint32_t length,
  * 544 code points, actually 542 characters CJK Radical Extension [2E80-2EFF]
  * 128 code points, actually 115 characters CJK Kangxi Radicals [2F00-2FDF] 224
  * code points, actually 214 characters CJK Strokes                  [31C0-31EF]
- * 48 code points, actually 36 characters CJK Compatibility [F900-FAFF]   512
+ * 48 code points, actually 36 characters Hangul Jamo              [1100-11FF]
+ * Hangul Compatibility Jamo [3130-318F] Hangul Syllables          [AC00-D7AF]
+ * Hangul Jamo Extended       [A960-A97F, D7B0-D7FF]
+ * CJK Compatibility          [F900-FAFF]   512
  * code points, actually 477 characters PUA (GBK)                    [E815-E86F]
  * 90 code points, actually 80 characters PUA Component Extension [E400-E5FF]
  * 511 code points, actually 452 characters PUA Character Supplement [E600-E6BF]
@@ -246,7 +249,28 @@ inline bool IsCJK(char32_t code) {
   return (code >= 0x4e00 && code <= 0x9FFF) ||
          (code >= 0x3400 && code <= 0x4dbf) ||
          (code >= 0x3040 && code <= 0x30ff) ||
+         (code >= 0x1100 && code <= 0x11ff) ||
+         (code >= 0x3130 && code <= 0x318f) ||
+         (code >= 0xa960 && code <= 0xa97f) ||
+         (code >= 0xac00 && code <= 0xd7ff) ||
          (code >= 0x20000 && code <= 0x2ffff);
+}
+inline bool IsWordSeparator(char32_t code) {
+  return code == 0x0020 || code == 0x00a0 || code == 0x1361 || code == 0x3000 ||
+         code == 0x10100 || code == 0x10101 || code == 0x1039f ||
+         code == 0x1091f;
+}
+inline bool IsCJKPunctuation(char32_t code) {
+  if ((code >= 0x3001 && code <= 0x303f) ||
+      (code >= 0xfe10 && code <= 0xfe1f) ||
+      (code >= 0xfe30 && code <= 0xfe6f) ||
+      (code >= 0xff01 && code <= 0xff0f) ||
+      (code >= 0xff1a && code <= 0xff20) ||
+      (code >= 0xff3b && code <= 0xff40) ||
+      (code >= 0xff5b && code <= 0xff65)) {
+    return true;
+  }
+  return false;
 }
 inline bool IsSpaceChar(char32_t code) {
   return code == ' ' || code == '\r' || code == '\n' || code == '\t' ||

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -16,6 +16,7 @@ executable("TextLayoutLiteTest") {
     "//demos/darwin/macos/ttreaderdemo/paragraph_test.cc",
     "boundary_analyst_test.cc",
     "inline_block_test.cc",
+    "justify_analyst_test.cc",
     "layout_drawer_test.cc",
     "layout_region_test.cc",
     "paragraph_image_test.cc",

--- a/test/golden_images/alignment.png
+++ b/test/golden_images/alignment.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:4fac3eaf3a56338eef4e067114aaf9728db865c3ed2ffc24c53f03a2f8b21c29
-size 91424
+oid sha256:a0d7ffa80820a60b99003d2678af12f481b5d7d718ff19f895ad44fc8bf844ae
+size 91165

--- a/test/golden_images/horizontal_alignment_test3_out.png
+++ b/test/golden_images/horizontal_alignment_test3_out.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:56fdb16746281277813b67067e7b2306405058bc3381e6c90f7bc1ac701d8709
-size 190969
+oid sha256:615b141a43f0ffac8f11bd6c3548bf90fd0bc6ef00ae6a02b076b48da1c8619d
+size 186305

--- a/test/golden_images/line_spacing.png
+++ b/test/golden_images/line_spacing.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e654ffd72e7df33de9a88dc6b88279e20f1642f8f1b8dfd46de716de61690b1f
-size 72377
+oid sha256:6966a79118af6c02fdc382a381159537c0771c74f83a15d4d57fb2ba2fc0d3dc
+size 71189

--- a/test/justify_analyst_test.cc
+++ b/test/justify_analyst_test.cc
@@ -1,0 +1,110 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/textlayout/internal/justify_analyst.h"
+
+#include <gtest/gtest.h>
+
+#include <initializer_list>
+#include <vector>
+
+using namespace ttoffice::tttext;
+
+namespace {
+void ExpectJustifyOpportunities(
+    const char* test_case, const char* text,
+    std::initializer_list<bool> expected_opportunities) {
+  SCOPED_TRACE(test_case);
+
+  const TTString content(text);
+  const JustifyAnalyst justify_analyst(content);
+  const std::vector<bool> expected(expected_opportunities);
+  const auto char_count = static_cast<CharPos>(expected.size());
+  ASSERT_EQ(content.GetCharCount(), char_count);
+
+  for (CharPos char_pos = 0; char_pos < char_count; ++char_pos) {
+    EXPECT_EQ(justify_analyst.CanInsertJustifySpaceAfter(char_pos),
+              static_cast<bool>(expected[char_pos]))
+        << "char_pos=" << char_pos;
+  }
+  EXPECT_FALSE(justify_analyst.CanInsertJustifySpaceAfter(char_count))
+      << "out-of-range char_pos";
+
+  for (CharPos start_char = 0; start_char <= char_count; ++start_char) {
+    auto next_opportunity = char_count;
+    for (CharPos char_pos = start_char; char_pos < char_count; ++char_pos) {
+      if (expected[char_pos]) {
+        next_opportunity = char_pos + 1;
+        break;
+      }
+    }
+    EXPECT_EQ(justify_analyst.FindNextJustifyOpportunity(start_char),
+              next_opportunity)
+        << "start_char=" << start_char;
+  }
+  EXPECT_EQ(justify_analyst.FindNextJustifyOpportunity(char_count + 1),
+            char_count)
+      << "start_char past end";
+}
+}  // namespace
+
+TEST(JustifyAnalystTest, JustifyOpportunity) {
+  ExpectJustifyOpportunities("empty paragraph", "", {});
+  ExpectJustifyOpportunities("single ASCII character", "A", {false});
+  ExpectJustifyOpportunities("ASCII word without separators", "abc",
+                             {false, false, false});
+  ExpectJustifyOpportunities("trailing separator", "A ", {false, false});
+
+  ExpectJustifyOpportunities("ASCII word separator", "A B",
+                             {false, true, false});
+  ExpectJustifyOpportunities("consecutive word separators", "A  B",
+                             {false, false, true, false});
+  ExpectJustifyOpportunities("non-breaking word separator",
+                             "A"
+                             u8"\u00a0"
+                             "B",
+                             {false, true, false});
+  ExpectJustifyOpportunities("non-ASCII word separator",
+                             "A"
+                             u8"\u1361"
+                             "B",
+                             {false, true, false});
+  ExpectJustifyOpportunities("ideographic word separator",
+                             "A"
+                             u8"\u3000"
+                             "B",
+                             {false, true, false});
+
+  ExpectJustifyOpportunities("Chinese and English boundaries", u8"A中B",
+                             {true, true, false});
+  ExpectJustifyOpportunities("Japanese kana and English boundaries",
+                             u8"AあBカC", {true, true, true, true, false});
+  ExpectJustifyOpportunities("Korean Hangul and English boundaries", u8"A한B",
+                             {true, true, false});
+  ExpectJustifyOpportunities("Chinese Japanese Korean boundaries", u8"中あ한",
+                             {true, true, false});
+
+  ExpectJustifyOpportunities("Chinese punctuation beside CJK text",
+                             u8"你，好。", {true, true, true, false});
+  ExpectJustifyOpportunities("Chinese punctuation beside ASCII text", u8"A，B",
+                             {true, true, false});
+  ExpectJustifyOpportunities("Chinese punctuation without CJK text", u8"，。",
+                             {true, false});
+  ExpectJustifyOpportunities("Chinese left and right punctuation", u8"（A）",
+                             {true, true, false});
+  ExpectJustifyOpportunities("CJK corner bracket punctuation", u8"「A」",
+                             {true, true, false});
+  ExpectJustifyOpportunities("fullwidth ASCII punctuation", u8"A．B",
+                             {true, true, false});
+  ExpectJustifyOpportunities(
+      "English punctuation", "Hi, there.",
+      {false, false, false, true, false, false, false, false, false, false});
+
+  ExpectJustifyOpportunities("ASCII digits", "12345",
+                             {false, false, false, false, false});
+  ExpectJustifyOpportunities("digits with word separator", "12 34",
+                             {false, false, true, false, false});
+  ExpectJustifyOpportunities("digits beside CJK text", u8"1中2",
+                             {true, true, false});
+}


### PR DESCRIPTION
- Add paragraph-level justify opportunity lookup
- Treat word separators, CJK/Hangul boundaries, and CJK punctuation as spacing opportunities
- Split justified drawer pieces by justify opportunities instead of word boundaries
- Preserve greedy break behavior for ellipsized last lines
- Add paragraph tests for separators, CJK boundaries, punctuation, digits, and edge cases