### PR TITLE
[Feature] support text skew in glyph drawing

### DIFF
--- a/platform/android/lynxtextra/src/main/java/com/lynx/textra/JavaCanvasHelper.java
+++ b/platform/android/lynxtextra/src/main/java/com/lynx/textra/JavaCanvasHelper.java
@@ -368,7 +368,7 @@ public class JavaCanvasHelper {
     paint_.setTypeface(ttfont.mTypeface);
     Paint p = ReadPaint(stream, paint_);
     p.setFakeBoldText(is_bold_);
-    p.setTextSkewX(is_italic_ ? -0.25f : 0f);
+    p.setTextSkewX((is_italic_ ? -0.25f : 0f) + text_skew_);
     p.setColor(color_);
     if (color_ != 0 && stroke_color_ == color_) {
       p.setStyle(Paint.Style.FILL_AND_STROKE);
@@ -453,6 +453,7 @@ public class JavaCanvasHelper {
     stroke_color_ = stream.readInt();
     text_size_ = TTTextUtils.Dp2Px(stream.readFloat());
     painter.setTextSize(text_size_);
+    text_skew_ = stream.readFloat();
     int flag = stream.readByte();
     is_bold_ = (flag & (1 << 2)) > 0;
     is_italic_ = (flag & (1 << 3)) > 0;
@@ -516,6 +517,7 @@ public class JavaCanvasHelper {
   protected boolean is_underline_;
 
   protected float text_size_;
+  protected float text_skew_;
 
   protected int color_;
   protected int stroke_color_;

--- a/public/textra/layout_definition.h
+++ b/public/textra/layout_definition.h
@@ -50,6 +50,7 @@ enum AttributeType : AttrType {
   kBackgroundPainter,
   kWordBreak,
   kBaselineOffset,
+  kTextSkew,
   kStyleManagerAttrEnd,
   kMaxAttrType = kStyleManagerAttrEnd,
   kExtraAttrStart = 128,

--- a/public/textra/painter.h
+++ b/public/textra/painter.h
@@ -55,6 +55,7 @@ class Painter {
         stroke_miter_(0),
         font_family_("pingfang"),
         text_size_(14),
+        text_skew_(0),
         bold_(false),
         italic_(false),
         under_line_(false),
@@ -82,6 +83,8 @@ class Painter {
   }
   float GetTextSize() const { return text_size_; }
   void SetTextSize(float text_size) { text_size_ = text_size; }
+  float GetTextSkew() const { return text_skew_; }
+  void SetTextSkew(float text_skew) { text_skew_ = text_skew; }
   bool IsBold() const { return bold_; }
   void SetBold(bool bold) { bold_ = bold; }
   bool IsItalic() const { return italic_; }
@@ -104,6 +107,7 @@ class Painter {
   float stroke_miter_;
   std::string font_family_;
   float text_size_;
+  float text_skew_;
   bool bold_;
   bool italic_;
   bool under_line_;

--- a/public/textra/platform/ios/ios_canvas_base.h
+++ b/public/textra/platform/ios/ios_canvas_base.h
@@ -290,6 +290,7 @@ class IOSCanvasBase : public tttext::ICanvasHelper {
     auto mode = ApplyPainterStyle(painter);
     CGContextSaveGState(context_);
     auto text_mat = CGAffineTransformIdentity;
+    auto text_skew = painter->GetTextSkew();
     if (painter->IsBold() || painter->IsItalic()) {
       NSDictionary* traits =
           (__bridge_transfer NSDictionary*)CTFontCopyTraits(ct_font);
@@ -313,12 +314,14 @@ class IOSCanvasBase : public tttext::ICanvasHelper {
         if ([obj isKindOfClass:[NSNumber class]]) {
           NSNumber* slant = reinterpret_cast<NSNumber*>(obj);
           if (slant.doubleValue == 0) {
-            // add fake slant
-            text_mat = CGAffineTransformConcat(
-                text_mat, CGAffineTransformMake(1, 0, 0.3, 1, 0, 0));
+            text_skew -= 0.3f;
           }
         }
       }
+    }
+    if (text_skew != 0) {
+      text_mat = CGAffineTransformConcat(
+          text_mat, CGAffineTransformMake(1, 0, -text_skew, 1, 0, 0));
     }
     CGContextSetTextMatrix(context_, text_mat);
     CGContextTranslateCTM(context_, ox, oy);

--- a/public/textra/platform/java/java_canvas_helper.h
+++ b/public/textra/platform/java/java_canvas_helper.h
@@ -170,6 +170,7 @@ class JavaCanvasHelper : public ICanvasHelper {
     stream_.WriteInt32(painter->GetFillColor());
     stream_.WriteInt32(painter->GetStrokeColor());
     stream_.WriteFloat(painter->GetTextSize());
+    stream_.WriteFloat(painter->GetTextSkew());
     int8_t flag = 0;
     if (painter->IsBold()) {
       flag = flag | (1 << 2);

--- a/public/textra/platform/skity/skity_canvas_helper.h
+++ b/public/textra/platform/skity/skity_canvas_helper.h
@@ -97,7 +97,8 @@ class SkityCanvasHelper : public ICanvasHelper {
     skity::Font skity_font(typeface->GetTypeface(), paint->GetTextSize());
     skity_font.SetHinting(skity::Font::FontHinting::kSlight);
     skity_font.SetEmbolden(painter->IsBold());
-    skity_font.SetSkewX(painter->IsItalic() ? -0.25f : 0);
+    skity_font.SetSkewX((painter->IsItalic() ? -0.25f : 0) +
+                        painter->GetTextSkew());
     runs.emplace_back(skity_font, glyph_vector, p_x, p_y);
 
     std::shared_ptr<skity::TextBlob> text_blob =

--- a/public/textra/style.h
+++ b/public/textra/style.h
@@ -417,6 +417,18 @@ class L_EXPORT Style {
   }
 
   /**
+   * @brief Horizontal skew applied during text rendering.
+   *
+   * Value: Float skew factor, default 0.0f.
+   */
+ public:
+  float GetTextSkew() const { return text_skew_; }
+  void SetTextSkew(const float& val) {
+    text_skew_ = val;
+    flag_ |= TextSkewFlag;
+  }
+
+  /**
    * @brief Text shadow effects.
    *
    * Enables multiple shadow effects on text, each with independent offset,
@@ -466,6 +478,7 @@ class L_EXPORT Style {
   static constexpr AttrType BackgroundPainterFlag = 1u << (kBackgroundPainter);
   static constexpr AttrType WordBreakFlag = 1u << (kWordBreak);
   static constexpr AttrType BaselineOffsetFlag = 1u << (kBaselineOffset);
+  static constexpr AttrType TextSkewFlag = 1u << (kTextSkew);
   static constexpr FlagType TextShadowListFlag = 1u << (kTextShadowList);
 
  public:
@@ -501,6 +514,7 @@ class L_EXPORT Style {
   Painter* bg_painter_ = nullptr;
   WordBreakType word_break_ = WordBreakType::kNormal;
   float baseline_offset_ = 0.f;
+  float text_skew_ = 0.f;
   TextShadowList text_shadow_list_{};
   FlagType flag_ = 0;
   mutable std::unique_ptr<ShapeStyle> shape_style_{};

--- a/src/textlayout/layout_drawer.cc
+++ b/src/textlayout/layout_drawer.cc
@@ -310,7 +310,7 @@ float LayoutDrawer::DrawTextRun(const BaseRun* run, uint32_t start_char_in_run,
           &style_range, run->GetStartCharPos() + piece_start,
           Style::ForegroundColorFlag | Style::ForegroundPainterFlag |
               Style::BaselineOffsetFlag | Style::TextStrokeStyleFlag |
-              Style::TextShadowListFlag);
+              Style::TextShadowListFlag | Style::TextSkewFlag);
       piece_end = std::min(char_end_pos, style_range.GetRange().GetEnd() -
                                              run->GetStartCharPos());
       style = &style_range.GetStyle();
@@ -341,6 +341,7 @@ float LayoutDrawer::DrawTextRun(const BaseRun* run, uint32_t start_char_in_run,
                              layout_style.GetTextScale());
       }
     }
+    painter->SetTextSkew(style->GetTextSkew());
     auto& result = run->shape_result_;
     auto glyph_start = result.CharToGlyph(piece_start);
     auto glyph_end = result.CharToGlyph(piece_end);

--- a/src/textlayout/style/style.cc
+++ b/src/textlayout/style/style.cc
@@ -61,6 +61,9 @@ Style& Style::operator=(const Style& other) {
   if (other.HasStyleAttribute(Style::BaselineOffsetFlag)) {
     SetBaselineOffset(other.GetBaselineOffset());
   }
+  if (other.HasStyleAttribute(Style::TextSkewFlag)) {
+    SetTextSkew(other.GetTextSkew());
+  }
   flag_ = other.flag_;
   return *this;
 }

--- a/src/textlayout/style/style_manager.cc
+++ b/src/textlayout/style/style_manager.cc
@@ -230,6 +230,8 @@ void StyleManager::SetStyle(Style* style, uint64_t value,
       return style->SetWordBreak(static_cast<WordBreakType>(value));
     case AttributeType::kBaselineOffset:
       return style->SetBaselineOffset(UnPackValue<float>(value));
+    case AttributeType::kTextSkew:
+      return style->SetTextSkew(UnPackValue<float>(value));
     default:
       TTASSERT(false);
   }
@@ -265,6 +267,8 @@ AttributesRangeList::ValueType StyleManager::GetStyleValue(
       return static_cast<uint64_t>(style->GetWordBreak());
     case AttributeType::kBaselineOffset:
       return PackValue(style->GetBaselineOffset());
+    case AttributeType::kTextSkew:
+      return PackValue(style->GetTextSkew());
     default:
       TTASSERT(false);
       AttributesRangeList::Undefined();

--- a/src/textlayout/style/style_manager.h
+++ b/src/textlayout/style/style_manager.h
@@ -252,6 +252,20 @@ class StyleManager {
                : UnPackValue<float>(value);
   }
 
+  void SetTextSkew(const float attr, const uint32_t start,
+                   const uint32_t len = 1) {
+    constexpr auto max_end = Range::MaxIndex();
+    const auto end = len > max_end - start ? max_end : start + len;
+    style_list_[kTextSkew].SetRangeValue(Range{start, end}, PackValue(attr));
+  }
+
+  float GetTextSkew(const uint32_t idx) const {
+    const auto value = style_list_[kTextSkew].GetAttrValue(idx);
+    return value == AttributesRangeList::Undefined()
+               ? (default_style_.GetTextSkew())
+               : UnPackValue<float>(value);
+  }
+
   using TextShadowList = std::vector<TextShadow>;
   void SetTextShadowList(const TextShadowList& attr, const uint32_t start,
                          const uint32_t len = 1) {

--- a/test/layout_drawer_test.cc
+++ b/test/layout_drawer_test.cc
@@ -107,6 +107,44 @@ TEST(LayoutDrawer, DrawLayoutPage_TextWithUnderline) {
   drawer.DrawLayoutPage(page.get());
 }
 
+TEST(LayoutDrawer, DrawTextRunPassesTextSkewToPainter) {
+  // Arrange
+  const char* text = "Hello";
+  const uint32_t text_length = strlen(text);
+  const float text_skew = -0.25f;
+  ParagraphImpl para;
+  Style style;
+  style.SetTextSize(1.f);
+  style.SetTextSkew(text_skew);
+  para.AddTextRun(&style, text);
+
+  TTTextContext context;
+  auto page = std::make_unique<LayoutRegion>(100.f, 100.f);
+  TextLayout layout(TestUtils::getTestShaper());
+  layout.Layout(&para, page.get(), context);
+
+  ASSERT_GT(page->GetLineCount(), 0u);
+  TextLine* text_line = page->GetLine(0);
+  ASSERT_NE(text_line, nullptr);
+
+  NiceMock<MockCanvasHelper> canvas_helper;
+  LayoutDrawer drawer(&canvas_helper);
+  ON_CALL(canvas_helper, CreatePainter()).WillByDefault(Invoke([]() {
+    return std::make_unique<Painter>();
+  }));
+
+  EXPECT_CALL(canvas_helper,
+              DrawGlyphs(_, text_length, _, nullptr, 0, _, _, _, _, _))
+      .WillOnce(Invoke([&](const ITypefaceHelper*, uint32_t, const uint16_t*,
+                           const char*, uint32_t, float, float, float*, float*,
+                           Painter* painter) {
+        EXPECT_FLOAT_EQ(painter->GetTextSkew(), text_skew);
+      }));
+
+  // Act
+  drawer.DrawTextLine(text_line, 0, text_length);
+}
+
 TEST(LayoutDrawer, DrawTextLine_ExclusiveEndDoesNotDrawNextDecoration) {
   // Arrange
   ParagraphImpl para;

--- a/test/style_manager_test.cc
+++ b/test/style_manager_test.cc
@@ -300,6 +300,13 @@ TEST(StyleManager, AttributeGettersAndSetters) {
   EXPECT_EQ(manager.GetBaselineOffset(1), baseline_offset);
   EXPECT_EQ(manager.GetBaselineOffset(5), baseline_offset);
   EXPECT_EQ(manager.GetBaselineOffset(6), default_style.GetBaselineOffset());
+  // Test TextSkew
+  const float text_skew = -0.25f;
+  manager.SetTextSkew(text_skew, 1, 5);
+  EXPECT_EQ(manager.GetTextSkew(0), default_style.GetTextSkew());
+  EXPECT_EQ(manager.GetTextSkew(1), text_skew);
+  EXPECT_EQ(manager.GetTextSkew(5), text_skew);
+  EXPECT_EQ(manager.GetTextSkew(6), default_style.GetTextSkew());
   // Test TextShadowList
   TextShadow shadow;
   StyleManager::TextShadowList expected_shadow_list{shadow};

--- a/test/style_test.cc
+++ b/test/style_test.cc
@@ -43,6 +43,7 @@ TEST(StyleTest, AttributeSetterGetterAndFlag) {
   SET_ATTRIBUTE_AND_CHECK_RESULT(BackgroundPainter, std::equal_to<>{});
   SET_ATTRIBUTE_AND_CHECK_RESULT(WordBreak, std::equal_to<>{});
   SET_ATTRIBUTE_AND_CHECK_RESULT(BaselineOffset, ttoffice::FloatsEqual);
+  SET_ATTRIBUTE_AND_CHECK_RESULT(TextSkew, ttoffice::FloatsEqual);
   {
     Style style;
     EXPECT_FALSE(style.HasStyleAttribute(Style::TextStrokeStyleFlag));


### PR DESCRIPTION
  Add text skew as a style and painter attribute, propagate it through
  LayoutDrawer, and apply it when drawing glyphs on iOS, Android Java, and Skity.

  Combine text skew with fake italic skew during rendering, with iOS converting
  the value for CoreText text matrix semantics. Add tests for style storage and
  painter propagation.