### PR TITLE
[Refactor] move UTF-8 character helper implementations to cc file

### DIFF
--- a/src/textlayout/utils/u_8_string.cc
+++ b/src/textlayout/utils/u_8_string.cc
@@ -175,5 +175,59 @@ uint32_t U32IndexToU16(const char32_t* u32str, uint32_t length,
   }
   return ret;
 }
+
+/*
+ * CJK Basic                    [4E00-9FFF]   20992 code points, actually 20940
+ * characters CJK Extension A              [3400-4DBF]   6592 code points,
+ * actually 6582 characters CJK Extension B              [20000-2A6DF] 42720
+ * code points, actually 42711 characters CJK Extension C [2A700-2B73F] 4159
+ * code points, actually 4149 characters CJK Extension D [2B740-2B81F] 224 code
+ * points, actually 222 characters CJK Compatibility Extension  [2F800-2FA1F]
+ * 544 code points, actually 542 characters CJK Radical Extension [2E80-2EFF]
+ * 128 code points, actually 115 characters CJK Kangxi Radicals [2F00-2FDF] 224
+ * code points, actually 214 characters CJK Strokes                  [31C0-31EF]
+ * 48 code points, actually 36 characters Hangul Jamo              [1100-11FF]
+ * Hangul Compatibility Jamo [3130-318F] Hangul Syllables          [AC00-D7AF]
+ * Hangul Jamo Extended       [A960-A97F, D7B0-D7FF]
+ * CJK Compatibility          [F900-FAFF]   512
+ * code points, actually 477 characters PUA (GBK)                    [E815-E86F]
+ * 90 code points, actually 80 characters PUA Component Extension [E400-E5FF]
+ * 511 code points, actually 452 characters PUA Character Supplement [E600-E6BF]
+ * 191 code points, actually 185 characters Hiragana & Katakana [3040-30ff]
+ */
+bool IsCJK(char32_t code) {
+  return (code >= 0x4e00 && code <= 0x9FFF) ||
+         (code >= 0x3400 && code <= 0x4dbf) ||
+         (code >= 0x3040 && code <= 0x30ff) ||
+         (code >= 0x1100 && code <= 0x11ff) ||
+         (code >= 0x3130 && code <= 0x318f) ||
+         (code >= 0xa960 && code <= 0xa97f) ||
+         (code >= 0xac00 && code <= 0xd7ff) ||
+         (code >= 0x20000 && code <= 0x2ffff);
+}
+
+bool IsWordSeparator(char32_t code) {
+  return code == 0x0020 || code == 0x00a0 || code == 0x1361 || code == 0x3000 ||
+         code == 0x10100 || code == 0x10101 || code == 0x1039f ||
+         code == 0x1091f;
+}
+
+bool IsCJKPunctuation(char32_t code) {
+  if ((code >= 0x3001 && code <= 0x303f) ||
+      (code >= 0xfe10 && code <= 0xfe1f) ||
+      (code >= 0xfe30 && code <= 0xfe6f) ||
+      (code >= 0xff01 && code <= 0xff0f) ||
+      (code >= 0xff1a && code <= 0xff20) ||
+      (code >= 0xff3b && code <= 0xff40) ||
+      (code >= 0xff5b && code <= 0xff65)) {
+    return true;
+  }
+  return false;
+}
+
+bool IsSpaceChar(char32_t code) {
+  return code == ' ' || code == '\r' || code == '\n' || code == '\t' ||
+         code == 0x3000;
+}
 }  // namespace base
 }  // namespace ttoffice

--- a/src/textlayout/utils/u_8_string.h
+++ b/src/textlayout/utils/u_8_string.h
@@ -226,56 +226,10 @@ inline std::u32string U16StringToU32(const std::u16string& u16str) {
 }
 uint32_t U32IndexToU16(const char32_t* content, uint32_t length,
                        uint32_t index);
-/*
- * CJK Basic                    [4E00-9FFF]   20992 code points, actually 20940
- * characters CJK Extension A              [3400-4DBF]   6592 code points,
- * actually 6582 characters CJK Extension B              [20000-2A6DF] 42720
- * code points, actually 42711 characters CJK Extension C [2A700-2B73F] 4159
- * code points, actually 4149 characters CJK Extension D [2B740-2B81F] 224 code
- * points, actually 222 characters CJK Compatibility Extension  [2F800-2FA1F]
- * 544 code points, actually 542 characters CJK Radical Extension [2E80-2EFF]
- * 128 code points, actually 115 characters CJK Kangxi Radicals [2F00-2FDF] 224
- * code points, actually 214 characters CJK Strokes                  [31C0-31EF]
- * 48 code points, actually 36 characters Hangul Jamo              [1100-11FF]
- * Hangul Compatibility Jamo [3130-318F] Hangul Syllables          [AC00-D7AF]
- * Hangul Jamo Extended       [A960-A97F, D7B0-D7FF]
- * CJK Compatibility          [F900-FAFF]   512
- * code points, actually 477 characters PUA (GBK)                    [E815-E86F]
- * 90 code points, actually 80 characters PUA Component Extension [E400-E5FF]
- * 511 code points, actually 452 characters PUA Character Supplement [E600-E6BF]
- * 191 code points, actually 185 characters Hiragana & Katakana [3040-30ff]
- */
-inline bool IsCJK(char32_t code) {
-  return (code >= 0x4e00 && code <= 0x9FFF) ||
-         (code >= 0x3400 && code <= 0x4dbf) ||
-         (code >= 0x3040 && code <= 0x30ff) ||
-         (code >= 0x1100 && code <= 0x11ff) ||
-         (code >= 0x3130 && code <= 0x318f) ||
-         (code >= 0xa960 && code <= 0xa97f) ||
-         (code >= 0xac00 && code <= 0xd7ff) ||
-         (code >= 0x20000 && code <= 0x2ffff);
-}
-inline bool IsWordSeparator(char32_t code) {
-  return code == 0x0020 || code == 0x00a0 || code == 0x1361 || code == 0x3000 ||
-         code == 0x10100 || code == 0x10101 || code == 0x1039f ||
-         code == 0x1091f;
-}
-inline bool IsCJKPunctuation(char32_t code) {
-  if ((code >= 0x3001 && code <= 0x303f) ||
-      (code >= 0xfe10 && code <= 0xfe1f) ||
-      (code >= 0xfe30 && code <= 0xfe6f) ||
-      (code >= 0xff01 && code <= 0xff0f) ||
-      (code >= 0xff1a && code <= 0xff20) ||
-      (code >= 0xff3b && code <= 0xff40) ||
-      (code >= 0xff5b && code <= 0xff65)) {
-    return true;
-  }
-  return false;
-}
-inline bool IsSpaceChar(char32_t code) {
-  return code == ' ' || code == '\r' || code == '\n' || code == '\t' ||
-         code == 0x3000;
-}
+bool IsCJK(char32_t code);
+bool IsWordSeparator(char32_t code);
+bool IsCJKPunctuation(char32_t code);
+bool IsSpaceChar(char32_t code);
 inline bool IsNoneVisibleASCII(char32_t code) { return code < 32; }
 }  // namespace base
 }  // namespace ttoffice


### PR DESCRIPTION
Move CJK, word separator, CJK punctuation, and space character helper implementations from u_8_string.h to u_8_string.cc, along with the related CJK range comment. Keep IsNoneVisibleASCII inline in the header.