### PR TITLE
[BugFix] account for italic and skew extra width

### DIFF
--- a/demos/darwin/macos/ttreaderdemo/paragraph_test.cc
+++ b/demos/darwin/macos/ttreaderdemo/paragraph_test.cc
@@ -770,7 +770,9 @@ void ParagraphTest::TestFontStyle(ICanvasHelper* canvas, float width) const {
   // TODO(hfuttyh): italic not working
   Style font_italic_rpr;
   font_italic_rpr.SetItalic(true);
-  paragraph.AddTextRun(&font_italic_rpr, "斜体字\n");
+  paragraph.AddTextRun(&font_italic_rpr, "斜体字");
+  font_italic_rpr.SetItalic(false);
+  paragraph.AddTextRun(&font_italic_rpr, "斜体后文本\n");
   Style decorator_rpr;
   decorator_rpr.SetDecorationType(DecorationType::kUnderLine);
   decorator_rpr.SetDecorationColor(TTColor(0xFF00FF00));
@@ -779,6 +781,12 @@ void ParagraphTest::TestFontStyle(ICanvasHelper* canvas, float width) const {
   paragraph.AddTextRun(&text_stroke, "文本描边:");
   text_stroke.SetTextStrokeStyle(TTColor::GREEN, 0.5);
   paragraph.AddTextRun(&text_stroke, "中国人, abc\n");
+  Style skew;
+  paragraph.AddTextRun(&skew, "skew倾斜:");
+  skew.SetTextSkew(-0.25);
+  paragraph.AddTextRun(&skew, "往前倾斜");
+  skew.SetTextSkew(0.25);
+  paragraph.AddTextRun(&skew, "往后倾斜\n");
   DrawParagraph(canvas, paragraph, width);
 }
 void ParagraphTest::TestCRLF(ICanvasHelper* canvas, float width) const {

--- a/public/textra/layout_definition.h
+++ b/public/textra/layout_definition.h
@@ -25,6 +25,7 @@ namespace tttext {
 using AttrType = uint32_t;
 constexpr float LAYOUT_MAX_UNITS = 10e5;
 constexpr float LAYOUT_MIN_UNITS = -10e5;
+constexpr float FAKE_ITALIC_SKEW = -0.25f;
 enum AttributeType : AttrType {
   kLayoutAttrStart = 0,
   kFontDescriptor = kLayoutAttrStart,

--- a/public/textra/platform/ark_graphics/ag_canvas_helper.h
+++ b/public/textra/platform/ark_graphics/ag_canvas_helper.h
@@ -18,6 +18,7 @@
 #include <native_drawing/drawing_sampling_options.h>
 #include <native_drawing/drawing_text_blob.h>
 #include <textra/i_canvas_helper.h>
+#include <textra/layout_definition.h>
 #include <textra/macro.h>
 #include <textra/painter.h>
 #include <textra/platform/ark_graphics/ag_typeface_helper.h>
@@ -223,7 +224,7 @@ class AGCanvasHelper : public ICanvasHelper {
     }
     OH_Drawing_CanvasTranslate(canvas_, origin_x, origin_y);
     if (painter->IsItalic()) {
-      OH_Drawing_CanvasSkew(canvas_, -0.3f, 0);
+      OH_Drawing_CanvasSkew(canvas_, FAKE_ITALIC_SKEW, 0);
     }
     OH_Drawing_CanvasDrawTextBlob(canvas_, textBlob, 0, 0);
     OH_Drawing_CanvasDetachBrush(canvas_);

--- a/public/textra/platform/ios/ios_canvas_base.h
+++ b/public/textra/platform/ios/ios_canvas_base.h
@@ -9,6 +9,7 @@
 #import <CoreText/CoreText.h>
 #import <UIKit/UIKit.h>
 #include <textra/i_canvas_helper.h>
+#include <textra/layout_definition.h>
 #include <textra/platform/ios/typeface_coretext.h>
 
 #include <memory>
@@ -314,7 +315,7 @@ class IOSCanvasBase : public tttext::ICanvasHelper {
         if ([obj isKindOfClass:[NSNumber class]]) {
           NSNumber* slant = reinterpret_cast<NSNumber*>(obj);
           if (slant.doubleValue == 0) {
-            text_skew -= 0.3f;
+            text_skew += FAKE_ITALIC_SKEW;
           }
         }
       }

--- a/public/textra/platform/mac/mac_canvas_base.h
+++ b/public/textra/platform/mac/mac_canvas_base.h
@@ -11,6 +11,7 @@
 #import <CoreGraphics/CoreGraphics.h>
 #import <CoreText/CoreText.h>
 #include <textra/i_canvas_helper.h>
+#include <textra/layout_definition.h>
 #include <textra/platform/ios/typeface_coretext.h>
 
 #include <memory>
@@ -318,7 +319,8 @@ class IOSCanvasBase : public tttext::ICanvasHelper {
           if (slant.doubleValue == 0) {
             // add fake slant
             text_mat = CGAffineTransformConcat(
-                text_mat, CGAffineTransformMake(1, 0, 0.3, 1, 0, 0));
+                text_mat,
+                CGAffineTransformMake(1, 0, -FAKE_ITALIC_SKEW, 1, 0, 0));
           }
         }
       }

--- a/public/textra/platform/skia/skia_canvas_helper.h
+++ b/public/textra/platform/skia/skia_canvas_helper.h
@@ -6,6 +6,7 @@
 #define PUBLIC_TEXTRA_PLATFORM_SKIA_SKIA_CANVAS_HELPER_H_
 
 #include <textra/i_canvas_helper.h>
+#include <textra/layout_definition.h>
 #include <textra/layout_drawer_listener.h>
 #include <textra/macro.h>
 #include <textra/platform/skia/skia_painter.h>
@@ -181,7 +182,7 @@ class L_EXPORT SkiaCanvasHelper : public tttext::ICanvasHelper {
     }
     auto typeface = reinterpret_cast<const tttext::SkiaTypefaceHelper*>(font);
     SkFont sk_font(typeface->GetSkTypeface(), painter->GetTextSize(), 1,
-                   painter->IsItalic() ? -0.25 : 0);
+                   painter->IsItalic() ? tttext::FAKE_ITALIC_SKEW : 0);
     SkTextBlobBuilder builder;
     auto run_buffer = builder.allocRunPosH(sk_font, glyph_count, 0, nullptr);
     for (uint32_t k = 0; k < glyph_count; k++) {

--- a/public/textra/platform/skity/skity_canvas_helper.h
+++ b/public/textra/platform/skity/skity_canvas_helper.h
@@ -6,6 +6,7 @@
 #define PUBLIC_TEXTRA_PLATFORM_SKITY_SKITY_CANVAS_HELPER_H_
 
 #include <textra/i_canvas_helper.h>
+#include <textra/layout_definition.h>
 #include <textra/painter.h>
 #include <textra/platform/skity/skity_typeface_helper.h>
 
@@ -97,7 +98,7 @@ class SkityCanvasHelper : public ICanvasHelper {
     skity::Font skity_font(typeface->GetTypeface(), paint->GetTextSize());
     skity_font.SetHinting(skity::Font::FontHinting::kSlight);
     skity_font.SetEmbolden(painter->IsBold());
-    skity_font.SetSkewX((painter->IsItalic() ? -0.25f : 0) +
+    skity_font.SetSkewX((painter->IsItalic() ? FAKE_ITALIC_SKEW : 0) +
                         painter->GetTextSkew());
     runs.emplace_back(skity_font, glyph_vector, p_x, p_y);
 

--- a/public/textra/style.h
+++ b/public/textra/style.h
@@ -487,7 +487,8 @@ class L_EXPORT Style {
       TextSizeFlag | TextScaleFlag | VerticalAlignmentFlag;
   static constexpr FlagType MeasureFlag =
       FontDescriptorFlag | SubSupFlag | LetterSpacingFlag;
-  static constexpr FlagType LayoutFlag = MeasureFlag | BoldFlag | ItalicFlag;
+  static constexpr FlagType LayoutFlag =
+      MeasureFlag | BoldFlag | ItalicFlag | TextSkewFlag;
   static constexpr FlagType DecorationFlag =
       DecorationColorFlag | DecorationStyleFlag | DecorationTypeFlag |
       DecorationThicknessMultiplierFlag;

--- a/src/ports/shaper/skshaper/one_line_shaper.cc
+++ b/src/ports/shaper/skshaper/one_line_shaper.cc
@@ -612,7 +612,7 @@ bool OneLineShaper::shape(const char32_t* content, uint32_t len,
     const bool fakeItalic = need_italic && typeface->FontStyle().GetSlant() !=
                                                FontStyle::kItalic_Slant;
     font.SetFakeBold(fakeBold);
-    font.SetSkewX(fakeItalic ? -0.25 : 0);
+    font.SetSkewX(fakeItalic ? FAKE_ITALIC_SKEW : 0);
 
     // Walk through all the currently unresolved blocks
     // (ignoring those that appear later)

--- a/src/textlayout/layout_drawer.cc
+++ b/src/textlayout/layout_drawer.cc
@@ -248,7 +248,9 @@ void LayoutDrawer::DrawDrawerPiece(const TextLine* line,
     auto glyph_count = glyph_end - glyph_start;
     std::vector<float> pos_x(glyph_count);
     std::vector<float> pos_y(glyph_count);
-    float char_x_pos = 0.f;
+    const auto skew_extra_width = run->GetSkewExtraWidth();
+    float char_x_pos =
+        FloatsLarger(skew_extra_width, 0.f) ? skew_extra_width : 0.f;
     for (uint32_t k = 0; k < glyph_count; k++) {
       auto invert_glyph_id =
           glyph_start + (run->IsRtl() ? glyph_count - k - 1 : k);

--- a/src/textlayout/run/base_run.cc
+++ b/src/textlayout/run/base_run.cc
@@ -7,6 +7,7 @@
 #include <textra/layout_definition.h>
 #include <textra/paragraph.h>
 
+#include <cmath>
 #include <memory>
 #include <utility>
 
@@ -20,7 +21,6 @@
 
 namespace ttoffice {
 namespace tttext {
-
 std::pair<RunType, const char*>* BaseRun::ControlRunList() {
   static std::pair<RunType, const char*> list[] = {
       {RunType::kNLFRun, base::NLF_STR()},
@@ -50,29 +50,57 @@ float BaseRun::GetWidth(uint32_t char_start_in_run, uint32_t char_count) const {
   TTASSERT(char_start_in_run < GetCharCount() && char_count <= GetCharCount());
   auto letter_spacing = layout_style_.GetLetterSpacing();
   return shape_result_.MeasureWidth(char_start_in_run, char_count,
-                                    letter_spacing);
+                                    letter_spacing) +
+         std::abs(GetSkewExtraWidth());
 }
 float BaseRun::MeasureRunByWidth(uint32_t& break_pos_in_run,
                                  float max_width) const {
   TTASSERT(break_pos_in_run < GetCharCount());
   TTASSERT(shape_result_.Valid());
+  auto advance_width = 0.f;
   auto width = 0.f;
   auto& idx = break_pos_in_run;
   uint32_t prev_glyph_id = -1;
   auto letter_spacing = layout_style_.GetLetterSpacing();
+  const auto skew_extra_width = std::abs(GetSkewExtraWidth());
   while (idx < GetCharCount()) {
     TTASSERT(idx < shape_result_.CharCount());
     auto glyph_id = shape_result_.CharToGlyph(idx);
     TTASSERT(glyph_id < shape_result_.GlyphCount());
     if (glyph_id != prev_glyph_id) {
       const auto ww = shape_result_.Advances(glyph_id)[0] + letter_spacing;
-      if (FloatsLarger(width + ww, max_width)) break;
-      width += ww;
+      const auto next_advance_width = advance_width + ww;
+      if (FloatsLarger(next_advance_width + skew_extra_width, max_width)) break;
+      advance_width = next_advance_width;
+      width = advance_width + skew_extra_width;
     }
     idx++;
     prev_glyph_id = glyph_id;
   }
   return width;
+}
+float BaseRun::GetSkewExtraWidth() const {
+  if (GetCharCount() == 0 || (!IsTextRun() && GetType() != RunType::kGhostRun))
+    return 0;
+
+  const auto& typeface = shape_result_.FontByCharId(0);
+  if (typeface == nullptr) return 0;
+
+  const auto& shape_style = layout_style_.GetShapeStyle();
+  const auto& desired_font_style = shape_style.GetFontDescriptor().font_style_;
+  auto skew = layout_style_.GetTextSkew();
+  auto fake_italic = layout_style_.GetItalic();
+  if (desired_font_style != typeface->FontStyle()) {
+    fake_italic = desired_font_style.GetSlant() == FontStyle::kItalic_Slant &&
+                  typeface->FontStyle().GetSlant() != FontStyle::kItalic_Slant;
+  }
+  if (fake_italic) {
+    skew += FAKE_ITALIC_SKEW;
+  }
+  if (FloatsEqual(skew, 0)) return 0;
+
+  const auto font_info = typeface->GetFontInfo(shape_style.GetFontSize());
+  return skew * std::abs(font_info.GetAscent());
 }
 LayoutMetrics BaseRun::CalculateLayoutMetrics(uint32_t start_char,
                                               uint32_t char_count,

--- a/src/textlayout/run/base_run.h
+++ b/src/textlayout/run/base_run.h
@@ -157,6 +157,7 @@ class BaseRun {
   const ShapeStyle& GetShapeStyle() const {
     return layout_style_.GetShapeStyle();
   }
+  float GetSkewExtraWidth() const;
   bool CanBeAppendToShaping(const BaseRun& prev_run) const {
     TTASSERT(!prev_run.IsGhostRun() && !prev_run.IsBlockRun());
     if (&prev_run == this) return true;

--- a/test/golden_images/font_style.png
+++ b/test/golden_images/font_style.png
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7248340e621fc1f3f6e3bebba5fd8ebe6663f157625ab97af206bd5b53a02deb
-size 17466
+oid sha256:578ba08e0f370d98917b8165b17d7276550482b1b1bba931b057f9a6e9cb16d4
+size 22859

--- a/test/run_test.cc
+++ b/test/run_test.cc
@@ -3,10 +3,13 @@
 // LICENSE file in the root directory of this source tree.
 
 #include <gtest/gtest.h>
+#include <textra/i_typeface_helper.h>
 #include <textra/layout_definition.h>
 
 #include <memory>
 #include <unordered_map>
+#include <utility>
+#include <vector>
 
 #include "src/textlayout/paragraph_impl.h"
 #include "src/textlayout/run/base_run.h"
@@ -15,6 +18,96 @@
 #include "test/test_utils.h"
 
 using namespace ttoffice::tttext;
+
+namespace {
+class TestTypeface final : public ITypefaceHelper {
+ public:
+  explicit TestTypeface(float ascent, ttoffice::tttext::FontStyle font_style =
+                                          ttoffice::tttext::FontStyle())
+      : ITypefaceHelper(1), ascent_(ascent) {
+    font_style_ = font_style;
+  }
+
+  float GetHorizontalAdvance(GlyphID glyph_id, float font_size) const override {
+    return 0;
+  }
+  void GetHorizontalAdvances(GlyphID glyph_ids[], uint32_t count,
+                             float widths[], float font_size) const override {}
+  void GetWidthBound(float* rect_ltwh, GlyphID glyph_id,
+                     float font_size) const override {}
+  void GetWidthBounds(float* rect_ltrb, GlyphID glyph_ids[],
+                      uint32_t glyph_count, float font_size) override {}
+  const void* GetFontData() const override { return nullptr; }
+  size_t GetFontDataSize() const override { return 0; }
+  int GetFontIndex() const override { return 0; }
+  uint16_t UnicharToGlyph(Unichar codepoint,
+                          uint32_t variationSelector = 0) const override {
+    return 0;
+  }
+  void UnicharsToGlyphs(const Unichar* unichars, uint32_t count,
+                        GlyphID* glyphs) const override {}
+  uint32_t GetUnitsPerEm() const override { return 0; }
+
+ protected:
+  void OnCreateFontInfo(FontInfo* info, float font_size) const override {
+    info->SetAscent(ascent_);
+    info->SetDescent(0);
+    info->SetFontSize(font_size);
+  }
+
+ private:
+  float ascent_;
+};
+
+class TestableBaseRun final : public BaseRun {
+ public:
+  using BaseRun::BaseRun;
+
+  void SetShapeResult(const ShapeResultRef& result, uint32_t char_count) {
+    shape_result_.InitWithShapeResult(result, 0, char_count);
+  }
+};
+
+class MultiFontShapingResultReader final
+    : public tttext::PlatformShapingResultReader {
+ public:
+  MultiFontShapingResultReader(float advance, std::vector<TypefaceRef> fonts)
+      : advance_(advance), fonts_(std::move(fonts)) {}
+
+  uint32_t GlyphCount() const override { return fonts_.size(); }
+  uint32_t TextCount() const override { return fonts_.size(); }
+  GlyphID ReadGlyphID(uint32_t idx) const override { return idx + 1; }
+  float ReadAdvanceX(uint32_t idx) const override { return advance_; }
+  uint32_t ReadIndices(uint32_t idx) const override { return idx; }
+  TypefaceRef ReadFontId(uint32_t idx) const override { return fonts_.at(idx); }
+
+ private:
+  float advance_;
+  std::vector<TypefaceRef> fonts_;
+};
+
+ShapeResultRef MakeShapeResult(uint32_t char_count, float advance,
+                               const TypefaceRef& typeface) {
+  TestShapingResultReader reader(char_count);
+  for (uint32_t i = 0; i < char_count; i++) {
+    reader.glyphs_[i] = i + 1;
+    reader.advances_[i] = {advance, 0};
+  }
+  reader.font_ = typeface;
+
+  auto result = std::make_shared<ShapeResult>(char_count, false);
+  result->AppendPlatformShapingResult(reader);
+  return result;
+}
+
+ShapeResultRef MakeMultiFontShapeResult(float advance,
+                                        std::vector<TypefaceRef> fonts) {
+  MultiFontShapingResultReader reader(advance, std::move(fonts));
+  auto result = std::make_shared<ShapeResult>(reader.TextCount(), false);
+  result->AppendPlatformShapingResult(reader);
+  return result;
+}
+}  // namespace
 
 TEST(BaseRun, Constructor) {
   ParagraphImpl paragraph;
@@ -103,4 +196,57 @@ TEST(ObjectRun, RunDelegate) {
   auto delegate = std::make_shared<TestShape>();
   run.SetRunDelegate(delegate);
   EXPECT_EQ(run.GetRunDelegate(), delegate.get());
+}
+
+TEST(BaseRun, GetWidthAddsTextSkewExtraWidth) {
+  ParagraphImpl paragraph;
+  Style style;
+  style.SetTextSkew(-0.25f);
+  TestableBaseRun run(&paragraph, style, 0, 2, RunType::kTextRun);
+  auto typeface = std::make_shared<TestTypeface>(-20.f);
+  run.SetShapeResult(MakeShapeResult(2, 10.f, typeface), 2);
+
+  EXPECT_FLOAT_EQ(run.GetWidth(0, 2), 25.f);
+}
+
+TEST(BaseRun, GetWidthAddsItalicExtraWidth) {
+  ParagraphImpl paragraph;
+  Style style;
+  style.SetItalic(true);
+  TestableBaseRun run(&paragraph, style, 0, 2, RunType::kTextRun);
+  auto typeface = std::make_shared<TestTypeface>(-20.f);
+  run.SetShapeResult(MakeShapeResult(2, 10.f, typeface), 2);
+
+  EXPECT_FLOAT_EQ(run.GetWidth(0, 2), 25.f);
+}
+
+TEST(BaseRun, GetWidthUsesFirstRunFontForSkewExtraWidth) {
+  ParagraphImpl paragraph;
+  Style style;
+  style.SetTextSkew(-0.25f);
+  TestableBaseRun run(&paragraph, style, 0, 2, RunType::kTextRun);
+  auto first_typeface = std::make_shared<TestTypeface>(-20.f);
+  auto second_typeface = std::make_shared<TestTypeface>(-100.f);
+  run.SetShapeResult(
+      MakeMultiFontShapeResult(10.f, {first_typeface, second_typeface}), 2);
+
+  EXPECT_FLOAT_EQ(run.GetWidth(0, 2), 25.f);
+  EXPECT_FLOAT_EQ(run.GetWidth(1, 1), 15.f);
+}
+
+TEST(BaseRun, MeasureRunByWidthIncludesSkewExtraWidth) {
+  ParagraphImpl paragraph;
+  Style style;
+  style.SetTextSkew(-0.25f);
+  TestableBaseRun run(&paragraph, style, 0, 2, RunType::kTextRun);
+  auto typeface = std::make_shared<TestTypeface>(-20.f);
+  run.SetShapeResult(MakeShapeResult(2, 10.f, typeface), 2);
+
+  uint32_t break_pos = 0;
+  EXPECT_FLOAT_EQ(run.MeasureRunByWidth(break_pos, 14.f), 0.f);
+  EXPECT_EQ(break_pos, 0u);
+
+  break_pos = 0;
+  EXPECT_FLOAT_EQ(run.MeasureRunByWidth(break_pos, 24.f), 15.f);
+  EXPECT_EQ(break_pos, 1u);
 }

--- a/test/text_layout_test.cc
+++ b/test/text_layout_test.cc
@@ -7,6 +7,7 @@
 #include <textra/text_layout.h>
 #include <textra/tttext_context.h>
 
+#include <cmath>
 #include <cstdint>
 #include <limits>
 #include <memory>
@@ -244,6 +245,50 @@ TEST_F(TextLayoutTest, DominantBaselineTopAlignsSmallerRun) {
 
   EXPECT_GT(rect_default[1], line_default->GetLineTop());
   EXPECT_FLOAT_EQ(rect_top[1], line_top->GetLineTop());
+}
+
+TEST_F(TextLayoutTest, GetCharBoundingRectIncludesItalicExtraWidth) {
+  const float text_size = 10.f;
+  auto para = std::make_unique<ParagraphImpl>();
+  Style style;
+  style.SetTextSize(text_size);
+  style.SetItalic(true);
+  para->AddTextRun(&style, "A");
+
+  TTTextContext context;
+  TextLayout layout(GetFixedSizeMockShaper());
+  auto region = std::make_unique<LayoutRegion>(100.f, 50.f);
+  layout.Layout(para.get(), region.get(), context);
+
+  ASSERT_EQ(region->GetLineCount(), 1u);
+  float rect[4]{};
+  region->GetLine(0)->GetCharBoundingRect(rect, 0);
+
+  const auto expected_extra_width =
+      std::abs(FAKE_ITALIC_SKEW) * 0.75f * text_size;
+  EXPECT_FLOAT_EQ(rect[2], text_size + expected_extra_width);
+}
+
+TEST_F(TextLayoutTest, GetCharBoundingRectIncludesTextSkewExtraWidth) {
+  const float text_size = 10.f;
+  const float text_skew = 0.2f;
+  auto para = std::make_unique<ParagraphImpl>();
+  Style style;
+  style.SetTextSize(text_size);
+  style.SetTextSkew(text_skew);
+  para->AddTextRun(&style, "A");
+
+  TTTextContext context;
+  TextLayout layout(GetFixedSizeMockShaper());
+  auto region = std::make_unique<LayoutRegion>(100.f, 50.f);
+  layout.Layout(para.get(), region.get(), context);
+
+  ASSERT_EQ(region->GetLineCount(), 1u);
+  float rect[4]{};
+  region->GetLine(0)->GetCharBoundingRect(rect, 0);
+
+  const auto expected_extra_width = text_skew * 0.75f * text_size;
+  EXPECT_FLOAT_EQ(rect[2], text_size + expected_extra_width);
 }
 
 TEST_F(TextLayoutTest, ParagraphStyle_HorizontalAlignment) {


### PR DESCRIPTION
Add run-level skew extra width to text measurement and width-based breaking, using the first run font's ascent for italic/text skew compensation.

Also offset glyph drawing when positive skew extends the visual bounds, align CoreText fake italic skew to 0.25, and include TextSkew in layout invalidation.

Add coverage for BaseRun width measurement and GetCharBoundingRect behavior, plus demo cases for italic/skew rendering.