### PR TITLE
[Infra] Support embedded GN config defaults

### DIFF
--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -12,10 +12,29 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if (target_cpu == "wasm") {
-  import("//config.gni")
-} else {
+declare_args() {
+  textlayout_use_local_config = true
+  textlayout_use_lru_cache = true
+  textlayout_boundary_analyst = "simple"
+  textlayout_dynamic_load_harfbuzz = is_android
+  textlayout_is_lvgl = false
+}
+
+if (textlayout_use_local_config) {
   import("../config.gni")
+}
+
+if (!defined(use_lru_cache)) {
+  use_lru_cache = textlayout_use_lru_cache
+}
+if (!defined(boundary_analyst)) {
+  boundary_analyst = textlayout_boundary_analyst
+}
+if (!defined(dynamic_load_harfbuzz)) {
+  dynamic_load_harfbuzz = textlayout_dynamic_load_harfbuzz
+}
+if (!defined(is_lvgl)) {
+  is_lvgl = textlayout_is_lvgl
 }
 
 declare_args() {

--- a/src/textlayout/run/base_run.h
+++ b/src/textlayout/run/base_run.h
@@ -48,7 +48,7 @@ class BaseRun {
 
  public:
   static constexpr const char* ObjectReplacementCharacter() {
-    return u8"\ufffc";
+    return "\xEF\xBF\xBC";
   }
 
   static std::pair<RunType, const char*>* ControlRunList();


### PR DESCRIPTION
Allows src/BUILD.gn to be embedded under a host GN source tree without importing TextLayout root config.gni and redeclaring host build args. Host-provided args such as use_lru_cache and boundary_analyst keep working; standalone builds still get fallback defaults.

Validation:
- Ran GN format dry-run for src/BUILD.gn.
- Verified Lynxtron gn gen locally with this TextLayout checkout and Skity GN targets.