### PR TITLE
[Testing] Add feature option to disable shape cache

### DIFF
--- a/public/textra/layout_definition.h
+++ b/public/textra/layout_definition.h
@@ -196,6 +196,7 @@ enum FeatureOption : uint8_t {
   kTrimLineTailSpace,
   kHarmonyShaperForceUseLowAPI,
   kSystemFontAdjust,
+  kDisableShapeCache,
 };
 enum class DominantBaseline : uint8_t {
   kAlphabetic,

--- a/src/textlayout/tt_shaper.cc
+++ b/src/textlayout/tt_shaper.cc
@@ -25,6 +25,7 @@
 #include "src/textlayout/run/base_run.h"
 #include "src/textlayout/shape_cache.h"
 #include "src/textlayout/style/style_manager.h"
+#include "src/textlayout/tttext_context_impl.h"
 #include "src/textlayout/utils/log_util.h"
 namespace ttoffice {
 namespace tttext {
@@ -64,7 +65,7 @@ std::unique_ptr<TTShaper> TTShaper::CreateShaper(
   return nullptr;
 }
 TTShaper::TTShaper(FontmgrCollection font_collection) noexcept
-    : font_collection_(font_collection) {}
+    : font_collection_(font_collection), context_(nullptr) {}
 TTShaper::~TTShaper() = default;
 void TTShaper::ProcessBidirection(const char32_t* text, uint32_t length,
                                   WriteDirection write_direction,
@@ -80,7 +81,10 @@ ShapeResultRef TTShaper::ShapeText(const char32_t* text, uint32_t length,
                                    const ShapeStyle* shape_style,
                                    bool rtl) const {
   const ShapeKey key(text, length, shape_style, rtl);
-  auto result = ShapeCache::GetInstance().Find(key);
+  const auto disable_shape_cache =
+      context_ != nullptr && context_->GetImpl().IsShapeCacheDisabled();
+  auto result =
+      disable_shape_cache ? nullptr : ShapeCache::GetInstance().Find(key);
   if (result == nullptr) {
     result = std::make_shared<ShapeResult>(length, rtl);
     OnShapeText(key, result.get());
@@ -92,7 +96,9 @@ ShapeResultRef TTShaper::ShapeText(const char32_t* text, uint32_t length,
         result->advances_[result->CharToGlyph(k)][1] = 0;
       }
     }
-    ShapeCache::GetInstance().AddToCache(key, result);
+    if (!disable_shape_cache) {
+      ShapeCache::GetInstance().AddToCache(key, result);
+    }
   }
   TTASSERT(result != nullptr);
   return result;

--- a/src/textlayout/tttext_context_impl.cc
+++ b/src/textlayout/tttext_context_impl.cc
@@ -20,6 +20,7 @@ TTTextContextImpl::TTTextContextImpl()
       trim_line_tail_space_(true),
       harmony_shaper_force_low_api_(false),
       enable_system_font_adjust_(false),
+      disable_shape_cache_(false),
       layout_bottom_(0) {}
 
 TTTextContext::TTTextContext() : impl_(std::make_unique<TTTextContextImpl>()) {}
@@ -75,6 +76,9 @@ void TTTextContext::EnableFeature(FeatureOption feature_option, bool value) {
       break;
     case kSystemFontAdjust:
       impl_->enable_system_font_adjust_ = value;
+      break;
+    case kDisableShapeCache:
+      impl_->disable_shape_cache_ = value;
       break;
     default:
       break;

--- a/src/textlayout/tttext_context_impl.h
+++ b/src/textlayout/tttext_context_impl.h
@@ -21,6 +21,7 @@ class TTTextContextImpl {
     return harmony_shaper_force_low_api_;
   }
   bool IsEnableSystemFontAdjust() const { return enable_system_font_adjust_; }
+  bool IsShapeCacheDisabled() const { return disable_shape_cache_; }
   bool IsTrimLineTailSpace() const { return trim_line_tail_space_; }
 
  private:
@@ -31,6 +32,7 @@ class TTTextContextImpl {
   bool trim_line_tail_space_;
   bool harmony_shaper_force_low_api_;
   bool enable_system_font_adjust_;
+  bool disable_shape_cache_;
   float layout_bottom_;
 };
 }  // namespace tttext


### PR DESCRIPTION
Add kDisableShapeCache to TTTextContext feature options and store the flag in TTTextContextImpl. TTShaper now checks the context flag before reading from or writing to ShapeCache, allowing callers to bypass shaping cache when needed.