### PR TITLE
[Feature] support start and end paragraph alignment

### DIFF
--- a/demos/darwin/macos/ttreaderdemo/paragraph_test.cc
+++ b/demos/darwin/macos/ttreaderdemo/paragraph_test.cc
@@ -15,6 +15,8 @@
 #include <textra/text_layout.h>
 #include <textra/tttext_context.h>
 
+#include <cmath>
+
 ParagraphTest::ParagraphTest(ShaperType type,
                              FontmgrCollection* font_collection)
     : shaper_type_(type),
@@ -113,6 +115,8 @@ ParagraphTest::GetTestCases() {
           {"TestIntrinsicWidth", &ParagraphTest::TestIntrinsicWidth},
           {"TestLongestLine", &ParagraphTest::TestLongestLine},
           {"TestAlignment", &ParagraphTest::TestAlignment},
+          {"TestStartEndAlignmentWithWriteDirection",
+           &ParagraphTest::TestStartEndAlignmentWithWriteDirection},
           {"TestBaselineOffset", &ParagraphTest::TestBaselineOffset},
           {"TestPieceDraw", &ParagraphTest::TestPieceDraw},
           {"TestWordBoundary", &ParagraphTest::TestWordBoundary},
@@ -1096,6 +1100,87 @@ The following is a relatively long English text, and it will wrap in the middle 
       ParagraphHorizontalAlignment::kJustify);
   DrawParagraph(canvas, *para, width);
 }
+
+void ParagraphTest::TestStartEndAlignmentWithWriteDirection(
+    ICanvasHelper* canvas, float width) const {
+  struct AlignmentCase {
+    const char* text;
+    WriteDirection write_direction;
+    ParagraphHorizontalAlignment alignment;
+    bool expect_left;
+    uint32_t background_color;
+  };
+
+  const AlignmentCase kCases[] = {
+      {"LTR start", WriteDirection::kLTR, ParagraphHorizontalAlignment::kStart,
+       true, 0x2200AA66},
+      {"LTR end", WriteDirection::kLTR, ParagraphHorizontalAlignment::kEnd,
+       false, 0x22DD6633},
+      {"RTL start", WriteDirection::kRTL, ParagraphHorizontalAlignment::kStart,
+       false, 0x2200AA66},
+      {"RTL end", WriteDirection::kRTL, ParagraphHorizontalAlignment::kEnd,
+       true, 0x22DD6633},
+      {"abc \xD7\x90\xD7\x91\xD7\x92", WriteDirection::kAuto,
+       ParagraphHorizontalAlignment::kStart, true, 0x2200AA66},
+      {"abc \xD7\x90\xD7\x91\xD7\x92", WriteDirection::kAuto,
+       ParagraphHorizontalAlignment::kEnd, false, 0x22DD6633},
+      {"\xD7\x90\xD7\x91\xD7\x92 abc", WriteDirection::kAuto,
+       ParagraphHorizontalAlignment::kStart, false, 0x2200AA66},
+      {"\xD7\x90\xD7\x91\xD7\x92 abc", WriteDirection::kAuto,
+       ParagraphHorizontalAlignment::kEnd, true, 0x22DD6633},
+  };
+
+  const float page_width = width > 220.f ? width : 220.f;
+  const float page_height = 35.f;
+  const float page_gap = 6.f;
+  const float position_tolerance = 0.5f;
+
+  canvas->Save();
+  for (const auto& test_case : kCases) {
+    Style style;
+    style.SetTextSize(24);
+    style.SetBackgroundColor(TTColor(test_case.background_color));
+
+    auto paragraph = Paragraph::Create();
+    auto& paragraph_style = paragraph->GetParagraphStyle();
+    paragraph_style.SetWriteDirection(test_case.write_direction);
+    paragraph_style.SetHorizontalAlign(test_case.alignment);
+    paragraph->AddTextRun(&style, test_case.text);
+
+    TextLayout layout(font_collection_, shaper_type_);
+    TTTextContext context;
+    context.SetSkipSpacingBeforeFirstLine(false);
+    context.SetLastLineCanOverflow(false);
+    auto page = std::make_unique<LayoutRegion>(
+        page_width, page_height, LayoutMode::kDefinite, LayoutMode::kAtMost);
+    layout.Layout(paragraph.get(), page.get(), context);
+
+    TTASSERT(page->GetLineCount() == 1u);
+    auto* line = page->GetLine(0);
+    TTASSERT(line != nullptr);
+    if (test_case.expect_left) {
+      TTASSERT(std::fabs(line->GetLineLeft()) < position_tolerance);
+    } else {
+      TTASSERT(std::fabs(line->GetLineRight() - page_width) <
+               position_tolerance);
+    }
+
+    LayoutDrawer drawer(canvas);
+    drawer.DrawLayoutPage(page.get());
+
+    auto paint = canvas->CreatePainter();
+    paint->SetStrokeColor(TTColor::BLACK);
+    canvas->DrawRect(0, 0, page_width, page_height, paint.get());
+    paint->SetStrokeColor(TTColor(0xFF1E88E5));
+    canvas->DrawLine(0, 0, 0, page_height, paint.get());
+    paint->SetStrokeColor(TTColor(0xFFD81B60));
+    canvas->DrawLine(page_width, 0, page_width, page_height, paint.get());
+
+    canvas->Translate(0, page_height + page_gap);
+  }
+  canvas->Restore();
+}
+
 void ParagraphTest::TestBaselineOffset(ICanvasHelper* canvas,
                                        float width) const {
   Style style;

--- a/demos/darwin/macos/ttreaderdemo/paragraph_test.h
+++ b/demos/darwin/macos/ttreaderdemo/paragraph_test.h
@@ -140,6 +140,8 @@ class ParagraphTest {
   void TestIntrinsicWidth(ICanvasHelper* canvas, float width) const;
   void TestLongestLine(ICanvasHelper* canvas, float width) const;
   void TestAlignment(ICanvasHelper* canvas, float width) const;
+  void TestStartEndAlignmentWithWriteDirection(ICanvasHelper* canvas,
+                                               float width) const;
   void TestBaselineOffset(ICanvasHelper* canvas, float width) const;
   void TestPieceDraw(ICanvasHelper* canvas, float width) const;
   void TestWordBoundary(ICanvasHelper* canvas, float width) const;

--- a/public/textra/layout_definition.h
+++ b/public/textra/layout_definition.h
@@ -75,6 +75,8 @@ enum class ParagraphHorizontalAlignment : uint8_t {
   kRight,
   kJustify,
   kDistributed,
+  kStart,
+  kEnd,
 };
 enum class ParagraphVerticalAlignment : uint8_t {
   kTop,

--- a/public/textra/paragraph_style.h
+++ b/public/textra/paragraph_style.h
@@ -62,7 +62,8 @@ class L_EXPORT ParagraphStyle {
    * @brief Horizontal text alignment within the paragraph.
    *
    * Controls how text lines are positioned horizontally within the available
-   * paragraph width. This affects text distribution and spacing.
+   * paragraph width. kStart and kEnd resolve to kLeft or kRight according to
+   * the paragraph writing direction.
    *
    * Value: See ParagraphHorizontalAlignment enum, default kLeft.
    *

--- a/src/textlayout/layout_measurer.cc
+++ b/src/textlayout/layout_measurer.cc
@@ -55,14 +55,13 @@ float LayoutMeasurer::CalcRunHeightByLinePitch(const Spacing& spacing,
 void LayoutMeasurer::ApplyLineHAlignment(TextLine* line) {
   auto* line_impl = TTDYNAMIC_CAST<TextLineImpl*>(line);
   auto& paragraph = *(line_impl->GetParagraph());
-  const auto* paragraph_style = &paragraph.GetParagraphStyle();
+  auto h_align = paragraph.GetResolvedHorizontalAlignment();
   auto last_line =
       // !paragraph_style->IsLastLineFollowHorizontalAlignment() &&
       !line->IsLastLineOfParagraph();
   for (auto idx = 0u; idx < line_impl->GetRangeCount(); idx++) {
     auto* range = line_impl->GetLineRange(idx);
-    ApplyHorizontalAlignment(paragraph_style->GetHorizontalAlign(), range,
-                             last_line);
+    ApplyHorizontalAlignment(h_align, range, last_line);
   }
 }
 void LayoutMeasurer::ApplyLineVAlignment(TextLine* line) {
@@ -99,6 +98,9 @@ void LayoutMeasurer::ApplyHorizontalAlignment(
   }
   switch (h_align) {
     case ParagraphHorizontalAlignment::kLeft:
+      break;
+    case ParagraphHorizontalAlignment::kStart:
+    case ParagraphHorizontalAlignment::kEnd:
       break;
     case ParagraphHorizontalAlignment::kCenter:
       // for (int k = 0; k < range->GetLogicWordCount(); k++) {

--- a/src/textlayout/paragraph_impl.cc
+++ b/src/textlayout/paragraph_impl.cc
@@ -33,8 +33,49 @@ ParagraphImpl::ParagraphImpl()
       style_manager_(std::make_unique<StyleManager>()),
       boundary_analyst_(nullptr),
       justify_analyst_(nullptr),
+      resolved_write_direction_(WriteDirection::kLTR),
       shaper_(nullptr) {}
 ParagraphImpl::~ParagraphImpl() = default;
+WriteDirection ParagraphImpl::ResolveWriteDirection(
+    WriteDirection direction, const std::vector<uint8_t>& bidi_level) {
+  if (direction != WriteDirection::kAuto) {
+    return direction;
+  }
+
+  if (!bidi_level.empty()) {
+    // ProcessBidirection has already resolved kAuto via the shaper's bidi
+    // wrapper. The lowest embedding level is the paragraph base level.
+    auto para_level = *std::min_element(bidi_level.begin(), bidi_level.end());
+    return para_level % 2 == 1 ? WriteDirection::kRTL : WriteDirection::kLTR;
+  }
+  return WriteDirection::kLTR;
+}
+WriteDirection ParagraphImpl::GetResolvedWriteDirection() const {
+  auto write_direction = paragraph_style_.GetWriteDirection();
+  if (write_direction != WriteDirection::kAuto) {
+    return write_direction;
+  }
+  return resolved_write_direction_;
+}
+ParagraphHorizontalAlignment ParagraphImpl::GetResolvedHorizontalAlignment()
+    const {
+  return ResolveHorizontalAlignment(paragraph_style_.GetHorizontalAlign());
+}
+ParagraphHorizontalAlignment ParagraphImpl::ResolveHorizontalAlignment(
+    ParagraphHorizontalAlignment h_align) const {
+  if (h_align != ParagraphHorizontalAlignment::kStart &&
+      h_align != ParagraphHorizontalAlignment::kEnd) {
+    return h_align;
+  }
+
+  const bool is_rtl = GetResolvedWriteDirection() == WriteDirection::kRTL;
+  if (h_align == ParagraphHorizontalAlignment::kStart) {
+    return is_rtl ? ParagraphHorizontalAlignment::kRight
+                  : ParagraphHorizontalAlignment::kLeft;
+  }
+  return is_rtl ? ParagraphHorizontalAlignment::kLeft
+                : ParagraphHorizontalAlignment::kRight;
+}
 void ParagraphImpl::AddTextRun(const Style& style, const char* content,
                                uint32_t length, bool ghost_text) {
   if (length == 0) {
@@ -121,6 +162,8 @@ void ParagraphImpl::FormatRunList() {
         u32_content.data(), static_cast<uint32_t>(u32_content.length()),
         paragraph_style_.GetWriteDirection(), visual_map_.data(),
         logical_map_.data(), bidi_level_.data());
+    resolved_write_direction_ = ResolveWriteDirection(
+        paragraph_style_.GetWriteDirection(), bidi_level_);
 
     bool need_split = false;
     for (auto k = 0u; k + 1 < GetCharCount(); k++) {

--- a/src/textlayout/paragraph_impl.h
+++ b/src/textlayout/paragraph_impl.h
@@ -140,6 +140,8 @@ class ParagraphImpl : public Paragraph {
                                           : bidi_level_[bidi_level_.size() - 1];
     return level % 2 == 1;
   }
+  WriteDirection GetResolvedWriteDirection() const;
+  ParagraphHorizontalAlignment GetResolvedHorizontalAlignment() const;
   LayoutPosition FindNextBoundary(const LayoutPosition& start,
                                   const BoundaryType& type) const;
   LayoutPosition FindPrevBoundary(const LayoutPosition& start,
@@ -161,6 +163,10 @@ class ParagraphImpl : public Paragraph {
     if (!text.empty()) content_ += text;
     return content_.GetCharCount();
   }
+  static WriteDirection ResolveWriteDirection(
+      WriteDirection direction, const std::vector<uint8_t>& bidi_level);
+  ParagraphHorizontalAlignment ResolveHorizontalAlignment(
+      ParagraphHorizontalAlignment h_align) const;
   bool SplitRun(uint32_t idx, uint32_t char_pos_in_run);
   void InitJustifyAnalyst() const;
 
@@ -176,6 +182,7 @@ class ParagraphImpl : public Paragraph {
   std::unique_ptr<StyleManager> style_manager_;
   std::unique_ptr<BoundaryAnalyst> boundary_analyst_;
   mutable std::unique_ptr<JustifyAnalyst> justify_analyst_;
+  WriteDirection resolved_write_direction_;
   // even: ltr, odd: rtl
   std::vector<uint8_t> bidi_level_;
   std::vector<uint32_t> visual_map_;

--- a/src/textlayout/text_line_impl.cc
+++ b/src/textlayout/text_line_impl.cc
@@ -239,19 +239,7 @@ bool TextLineImpl::StripContentByWidth(float space) {
 void TextLineImpl::AppendGhostRun(std::unique_ptr<BaseRun> ghost_run) {
   auto drawer_piece = std::make_unique<RunRange>(
       ghost_run.get(), range_lst_.back().get(), 0, ghost_run->GetCharCount());
-  // Invalid paragraph direction for now
-  WriteDirection para_dir = paragraph_->GetParagraphStyle().GetWriteDirection();
-  TTASSERT(para_dir != WriteDirection::kTTB &&
-           para_dir != WriteDirection::kBTT);
-  if (para_dir == WriteDirection::kAuto) {
-    // Follow the way of paragraph direction detection in Lynx
-    if (GetParagraph()->GetCharCount() > 0 &&
-        GetParagraph()->IsRtlCharacter(0)) {
-      para_dir = WriteDirection::kRTL;
-    } else {
-      para_dir = WriteDirection::kLTR;
-    }
-  }
+  WriteDirection para_dir = paragraph_->GetResolvedWriteDirection();
   if (para_dir == WriteDirection::kRTL) {
     std::vector<std::unique_ptr<DrawerPiece>> drawer_list;
     drawer_list.emplace_back(std::move(drawer_piece));
@@ -277,11 +265,11 @@ void TextLineImpl::ModifyHorizontalAlignment(
 }
 
 void TextLineImpl::ApplyAlignment() {
-  ApplyAlignment(paragraph_->GetParagraphStyle().GetHorizontalAlign());
+  ApplyAlignment(paragraph_->GetResolvedHorizontalAlignment());
 }
 
 void TextLineImpl::ApplyAlignment(ParagraphHorizontalAlignment h_align) {
-  const auto align = h_align;
+  const auto align = paragraph_->ResolveHorizontalAlignment(h_align);
   auto drawer_iter_begin = drawer_list_.begin();
   while (drawer_iter_begin != drawer_list_.end()) {
     const auto* line_range = (*drawer_iter_begin)->GetParent();
@@ -392,7 +380,7 @@ void TextLineImpl::StripByEllipsis(const char32_t* ellipsis) {
   auto ellipsis_len = base::U32Strlen(ellipsis);
   if ((ellipsis != nullptr && ellipsis_len > 0) ||
       para_style.GetEllipsisDelegate() != nullptr) {
-    if (para_style.GetHorizontalAlign() !=
+    if (paragraph_->GetResolvedHorizontalAlignment() !=
         ParagraphHorizontalAlignment::kLeft) {
       // re-generate drawer piece
       CreateDrawerPiece();

--- a/test/text_layout_test.cc
+++ b/test/text_layout_test.cc
@@ -295,22 +295,32 @@ TEST_F(TextLayoutTest, ParagraphStyle_HorizontalAlignment) {
   const char* text = "Hello world!";  // 12 characters, each 1 x 1 size
   const float page_width = 10.5f;     // Line fits 10 characters + 0.5 spacing
 
-  const auto layout_helper = [this, page_width,
-                              text](ParagraphHorizontalAlignment alignment) {
-    auto para = std::make_unique<ParagraphImpl>();
-    ParagraphStyle para_style;
-    Style style;
-    style.SetTextSize(1.f);
-    para_style.SetDefaultStyle(style);
-    para_style.SetHorizontalAlign(alignment);
-    para->SetParagraphStyle(&para_style);
-    para->AddTextRun(nullptr, text);
-    TTTextContext context;
-    TextLayout layout(GetFixedSizeMockShaper());
-    auto region = std::make_unique<LayoutRegion>(page_width, 10.f);
-    layout.Layout(para.get(), region.get(), context);
-    return std::make_pair(std::move(para), std::move(region));
-  };
+  const auto layout_helper =
+      [this, page_width, text](ParagraphHorizontalAlignment alignment,
+                               WriteDirection direction = WriteDirection::kLTR,
+                               const char* content = nullptr,
+                               bool use_real_shaper = false) {
+        auto para = std::make_unique<ParagraphImpl>();
+        ParagraphStyle para_style;
+        Style style;
+        style.SetTextSize(1.f);
+        para_style.SetDefaultStyle(style);
+        para_style.SetHorizontalAlign(alignment);
+        para_style.SetWriteDirection(direction);
+        para->SetParagraphStyle(&para_style);
+        para->AddTextRun(nullptr, content == nullptr ? text : content);
+        TTTextContext context;
+        std::unique_ptr<TTShaper> shaper;
+        if (use_real_shaper) {
+          shaper = TestUtils::getRealShaper();
+        } else {
+          shaper = GetFixedSizeMockShaper();
+        }
+        TextLayout layout(std::move(shaper));
+        auto region = std::make_unique<LayoutRegion>(page_width, 10.f);
+        layout.Layout(para.get(), region.get(), context);
+        return std::make_pair(std::move(para), std::move(region));
+      };
 
   {
     auto [_, region] = layout_helper(ParagraphHorizontalAlignment::kLeft);
@@ -347,6 +357,58 @@ TEST_F(TextLayoutTest, ParagraphStyle_HorizontalAlignment) {
     EXPECT_GT(second_line->GetLineLeft(), 0.f);
     EXPECT_FLOAT_EQ(first_line->GetLineRight(), page_width);
     EXPECT_FLOAT_EQ(second_line->GetLineRight(), page_width);
+  }
+  {
+    auto [_, region] = layout_helper(ParagraphHorizontalAlignment::kStart,
+                                     WriteDirection::kLTR);
+    EXPECT_EQ(region->GetLineCount(), 2u);
+    auto* first_line = region->GetLine(0);
+    auto* second_line = region->GetLine(1);
+    EXPECT_FLOAT_EQ(first_line->GetLineLeft(), 0.f);
+    EXPECT_FLOAT_EQ(second_line->GetLineLeft(), 0.f);
+  }
+  {
+    auto [_, region] =
+        layout_helper(ParagraphHorizontalAlignment::kEnd, WriteDirection::kLTR);
+    EXPECT_EQ(region->GetLineCount(), 2u);
+    auto* first_line = region->GetLine(0);
+    auto* second_line = region->GetLine(1);
+    EXPECT_FLOAT_EQ(first_line->GetLineRight(), page_width);
+    EXPECT_FLOAT_EQ(second_line->GetLineRight(), page_width);
+  }
+  {
+    auto [_, region] = layout_helper(ParagraphHorizontalAlignment::kStart,
+                                     WriteDirection::kRTL);
+    EXPECT_EQ(region->GetLineCount(), 2u);
+    auto* first_line = region->GetLine(0);
+    auto* second_line = region->GetLine(1);
+    EXPECT_FLOAT_EQ(first_line->GetLineRight(), page_width);
+    EXPECT_FLOAT_EQ(second_line->GetLineRight(), page_width);
+  }
+  {
+    auto [_, region] =
+        layout_helper(ParagraphHorizontalAlignment::kEnd, WriteDirection::kRTL);
+    EXPECT_EQ(region->GetLineCount(), 2u);
+    auto* first_line = region->GetLine(0);
+    auto* second_line = region->GetLine(1);
+    EXPECT_FLOAT_EQ(first_line->GetLineLeft(), 0.f);
+    EXPECT_FLOAT_EQ(second_line->GetLineLeft(), 0.f);
+  }
+  {
+    const char* auto_rtl_text = "123 \xD7\x90\xD7\x91";
+    auto [_, region] =
+        layout_helper(ParagraphHorizontalAlignment::kStart,
+                      WriteDirection::kAuto, auto_rtl_text, true);
+    EXPECT_EQ(region->GetLineCount(), 1u);
+    EXPECT_FLOAT_EQ(region->GetLine(0)->GetLineRight(), page_width);
+  }
+  {
+    const char* auto_rtl_text = "123 \xD7\x90\xD7\x91";
+    auto [_, region] =
+        layout_helper(ParagraphHorizontalAlignment::kEnd, WriteDirection::kAuto,
+                      auto_rtl_text, true);
+    EXPECT_EQ(region->GetLineCount(), 1u);
+    EXPECT_FLOAT_EQ(region->GetLine(0)->GetLineLeft(), 0.f);
   }
   {
     auto [_, region] = layout_helper(ParagraphHorizontalAlignment::kJustify);
@@ -635,6 +697,41 @@ TEST_F(TextLayoutTest, ParagraphStyle_WriteDirection) {
     // Expected output: "...The quick"
     EXPECT_FLOAT_EQ(text_run_rect[0], strlen(ellipsis) * text_size);
   }
+}
+
+TEST_F(TextLayoutTest, ParagraphStyle_WriteDirectionUpdatesAfterLayout) {
+  const char* text = "The quick brown fox jumps over the lazy dog.";
+  const float page_width = 12.0f;
+  const float page_height = 3.0f;
+  const float text_size = 1.0f;
+  const char* ellipsis = "...";
+
+  auto para = std::make_unique<ParagraphImpl>();
+  Style style;
+  style.SetTextSize(text_size);
+  auto& para_style = para->GetParagraphStyle();
+  para_style.SetDefaultStyle(style);
+  para_style.SetWriteDirection(WriteDirection::kLTR);
+  para->AddTextRun(&style, text);
+
+  TextLayout layout(GetFixedSizeMockShaper());
+  TTTextContext context;
+  auto initial_region = std::make_unique<LayoutRegion>(page_width, page_height);
+  layout.Layout(para.get(), initial_region.get(), context);
+
+  para_style.SetWriteDirection(WriteDirection::kRTL);
+  para_style.SetMaxLines(1);
+  para_style.SetEllipsis(ellipsis);
+
+  TTTextContext rtl_context;
+  auto rtl_region = std::make_unique<LayoutRegion>(page_width, page_height);
+  layout.Layout(para.get(), rtl_region.get(), rtl_context);
+
+  ASSERT_EQ(rtl_region->GetLineCount(), 1u);
+  auto* line = rtl_region->GetLine(0);
+  float text_run_rect[4];
+  line->GetCharBoundingRect(text_run_rect, line->GetStartCharPos());
+  EXPECT_FLOAT_EQ(text_run_rect[0], strlen(ellipsis) * text_size);
 }
 
 TEST_F(TextLayoutTest, ParagraphStyle_Ellipsis) {


### PR DESCRIPTION
Add kStart and kEnd horizontal alignment values and resolve them from the paragraph writing direction.

Cache resolved paragraph direction after bidi processing and use it for line alignment and ellipsis ghost run placement. Add LTR, RTL, and auto-direction coverage for logical alignment.