### PR TITLE
[Feature] make underline offset configurable

### DIFF
--- a/examples/json_parser/json_parser.cc
+++ b/examples/json_parser/json_parser.cc
@@ -342,6 +342,12 @@ Style ParseStyle(const Value& style_data) {
     style.SetDecorationSideMargin(side_margin);
   }
 
+  // Parse DecorationOffset
+  if (HasOptionalField(style_data, "decoration_offset")) {
+    auto offset = GetRequiredField<float>(style_data, "decoration_offset");
+    style.SetDecorationOffset(offset);
+  }
+
   // Parse Bold
   if (HasOptionalField(style_data, "bold")) {
     auto bold = GetRequiredField<bool>(style_data, "bold");

--- a/examples/json_parser/specification.json
+++ b/examples/json_parser/specification.json
@@ -213,6 +213,10 @@
                         // [Number] Maximum side margin for dashed decoration lines
                         // [Optional] Default: 2.5
                         "decoration_side_margin": 2.5,
+                        // decoration_offset
+                        // [Number] Underline offset from line bottom in pixels
+                        // [Optional] Default: -2.0
+                        "decoration_offset": -2.0,
                         // bold
                         // [Boolean] Whether text is bold
                         // [Optional] Default: false

--- a/public/textra/layout_definition.h
+++ b/public/textra/layout_definition.h
@@ -55,6 +55,7 @@ enum AttributeType : AttrType {
   kDecorationElementLength,
   kDecorationGapLength,
   kDecorationSideMargin,
+  kDecorationOffset,
   kStyleManagerAttrEnd,
   kMaxAttrType = kStyleManagerAttrEnd,
   kExtraAttrStart = 128,

--- a/public/textra/style.h
+++ b/public/textra/style.h
@@ -12,6 +12,7 @@
 #include <textra/tt_color.h>
 
 #include <cmath>
+#include <cstdint>
 #include <limits>
 #include <memory>
 #include <vector>
@@ -33,6 +34,111 @@ union DecorationStyle {
     LineType line_type_ : 8;
     uint8_t padding_ : 8;
   } style_;
+};
+
+enum StyleValueType : uint8_t {
+  kStyleValueInvalid,
+  kStyleValueBool,
+  kStyleValueFloat,
+  kStyleValueInt64,
+  kStyleValuePointer,
+};
+
+struct StyleValue {
+  StyleValueType type;
+  union {
+    int64_t i64;
+    float f32;
+    intptr_t ptr;
+  };
+  int64_t length;
+
+  StyleValue() : type(kStyleValueInvalid), ptr(0), length(0) {}
+  StyleValue(bool value)
+      : type(kStyleValueBool),
+        i64(static_cast<int64_t>(value)),
+        length(sizeof(int64_t)) {}
+  StyleValue(int32_t value)
+      : type(kStyleValueInt64),
+        i64(static_cast<int64_t>(value)),
+        length(sizeof(int64_t)) {}
+  StyleValue(uint32_t value)
+      : type(kStyleValueInt64),
+        i64(static_cast<int64_t>(value)),
+        length(sizeof(int64_t)) {}
+  StyleValue(float value)
+      : type(kStyleValueFloat), f32(value), length(sizeof(float)) {}
+  StyleValue(int64_t value)
+      : type(kStyleValueInt64), i64(value), length(sizeof(int64_t)) {}
+  StyleValue(uint64_t value)
+      : type(kStyleValueInt64),
+        i64(static_cast<int64_t>(value)),
+        length(sizeof(int64_t)) {}
+  StyleValue(double value) = delete;
+  StyleValue(const void* value, int64_t len = 0)
+      : type(kStyleValuePointer),
+        ptr(reinterpret_cast<intptr_t>(value)),
+        length(len) {}
+
+  bool IsValid() const { return type != kStyleValueInvalid; }
+  bool IsBoolean() const { return type == kStyleValueBool; }
+  bool IsPointer() const { return type == kStyleValuePointer; }
+  bool IsNumber() const {
+    return type == kStyleValueFloat || type == kStyleValueInt64;
+  }
+
+  bool Bool() const { return IsBoolean() ? i64 != 0 : false; }
+  int32_t Int32() const {
+    switch (type) {
+      case kStyleValueFloat:
+        return static_cast<int32_t>(f32);
+      case kStyleValueInt64:
+        return static_cast<int32_t>(i64);
+      default:
+        return 0;
+    }
+  }
+  uint32_t UInt32() const {
+    switch (type) {
+      case kStyleValueFloat:
+        return static_cast<uint32_t>(f32);
+      case kStyleValueInt64:
+        return static_cast<uint32_t>(i64);
+      default:
+        return 0;
+    }
+  }
+  float Float() const {
+    switch (type) {
+      case kStyleValueFloat:
+        return f32;
+      case kStyleValueInt64:
+        return static_cast<float>(i64);
+      default:
+        return 0.f;
+    }
+  }
+  int64_t Int64() const {
+    switch (type) {
+      case kStyleValueFloat:
+        return static_cast<int64_t>(f32);
+      case kStyleValueInt64:
+        return i64;
+      default:
+        return 0;
+    }
+  }
+  uint64_t UInt64() const {
+    switch (type) {
+      case kStyleValueFloat:
+        return static_cast<uint64_t>(f32);
+      case kStyleValueInt64:
+        return static_cast<uint64_t>(i64);
+      default:
+        return 0;
+    }
+  }
+  intptr_t Pointer() const { return IsPointer() ? ptr : 0; }
 };
 
 /**
@@ -279,6 +385,17 @@ class L_EXPORT Style {
   }
 
   /**
+   * @brief General style getter/setter.
+   *
+   * This tagged-value API is intended for bindings and dynamic style bridges.
+   * Use the typed accessors above in C++ code when the attribute is known.
+   */
+ public:
+  StyleValue GetAttribute(AttributeType attribute) const;
+  bool GetAttribute(AttributeType attribute, StyleValue* value) const;
+  bool SetAttribute(AttributeType attribute, const StyleValue& value);
+
+  /**
    * @brief Text Stroke Style.
    *
    * Useful for setting text stroke style
@@ -507,6 +624,9 @@ class L_EXPORT Style {
   }
 
  public:
+  static constexpr AttrType GetAttrType(const AttributeType type) {
+    return 1u << type;
+  }
   static constexpr AttrType FontDescriptorFlag = 1u << (kFontDescriptor);
   static constexpr AttrType TextSizeFlag = 1u << (kTextSize);
   static constexpr AttrType TextScaleFlag = 1u << (kTextScale);
@@ -523,6 +643,7 @@ class L_EXPORT Style {
                                                       << (kDecorationGapLength);
   static constexpr AttrType DecorationSideMarginFlag =
       1u << (kDecorationSideMargin);
+  static constexpr AttrType DecorationOffsetFlag = 1u << (kDecorationOffset);
   static constexpr AttrType TextStrokeStyleFlag = 1u << (kTextStrokeStyle);
   static constexpr AttrType BoldFlag = 1u << (kBold);
   static constexpr AttrType ItalicFlag = 1u << (kItalic);
@@ -547,7 +668,7 @@ class L_EXPORT Style {
   static constexpr FlagType DecorationFlag =
       DecorationColorFlag | DecorationStyleFlag | DecorationTypeFlag |
       DecorationThicknessMultiplierFlag | DecorationElementLengthFlag |
-      DecorationGapLengthFlag | DecorationSideMarginFlag;
+      DecorationGapLengthFlag | DecorationSideMarginFlag | DecorationOffsetFlag;
 
  private:
   FontDescriptor font_descriptor_{{}, FontStyle::Normal(), 0};
@@ -562,6 +683,7 @@ class L_EXPORT Style {
   float decoration_element_length_ = 2.5f;
   float decoration_gap_length_ = 1.5f;
   float decoration_side_margin_ = 2.5f;
+  float decoration_offset_ = -2.f;
   DecorationStyle text_stroke_ = {
       .style_ = {TTColor::UNDEFINED, 10, LineType::kSolid}};
   bool bold_ = false;

--- a/src/textlayout/layout_drawer.cc
+++ b/src/textlayout/layout_drawer.cc
@@ -150,11 +150,9 @@ void LayoutDrawer::DrawLineDecoration(TextLine* i_line,
           TTASSERT(false);
           break;
         case DecorationType::kUnderLine: {
-          // TODO(hfuttyh): Improve underline positioning by:
-          // 1. Reading font's suggested position
-          // 2. Allowing client to specify an offset
-          constexpr float kDefaultUnderlineOffset = -2.f;
-          line_y = line->GetLineBottom() + kDefaultUnderlineOffset;
+          // TODO(hfuttyh): Read font's suggested underline position.
+          line_y = line->GetLineBottom() +
+                   decorate_style.GetAttribute(kDecorationOffset).Float();
           break;
         }
         case DecorationType::kOverline:

--- a/src/textlayout/style/style.cc
+++ b/src/textlayout/style/style.cc
@@ -44,6 +44,8 @@ Style& Style::operator=(const Style& other) {
     SetDecorationGapLength(other.GetDecorationGapLength());
   if (other.HasStyleAttribute(Style::DecorationSideMarginFlag))
     SetDecorationSideMargin(other.GetDecorationSideMargin());
+  if (other.HasStyleAttribute(Style::DecorationOffsetFlag))
+    SetAttribute(kDecorationOffset, other.GetAttribute(kDecorationOffset));
   if (other.HasStyleAttribute(Style::TextStrokeStyleFlag)) {
     SetTextStrokeValue(other.GetTextStrokeValue());
   }
@@ -81,6 +83,262 @@ const ShapeStyle& Style::GetShapeStyle() const {
         font_descriptor_, GetScaledTextSize(), false, false);
   }
   return *shape_style_;
+}
+bool Style::SetAttribute(AttributeType attribute, const StyleValue& value) {
+  switch (attribute) {
+    case kFontDescriptor: {
+      if (!value.IsPointer() || value.Pointer() == 0 ||
+          value.length != sizeof(FontDescriptor)) {
+        return false;
+      }
+      SetFontDescriptor(
+          *reinterpret_cast<const FontDescriptor*>(value.Pointer()));
+      return true;
+    }
+    case kTextSize:
+      if (!value.IsNumber()) {
+        return false;
+      }
+      SetTextSize(value.Float());
+      return true;
+    case kTextScale:
+      if (!value.IsNumber()) {
+        return false;
+      }
+      SetTextScale(value.Float());
+      return true;
+    case kVerticalAlignment:
+      if (!value.IsNumber()) {
+        return false;
+      }
+      SetVerticalAlignment(
+          static_cast<CharacterVerticalAlignment>(value.Int32()));
+      return true;
+    case kWordSpacing:
+      if (!value.IsNumber()) {
+        return false;
+      }
+      SetWordSpacing(value.Float());
+      return true;
+    case kLetterSpacing:
+      if (!value.IsNumber()) {
+        return false;
+      }
+      SetLetterSpacing(value.Float());
+      return true;
+    case kForegroundColor:
+      if (!value.IsNumber()) {
+        return false;
+      }
+      SetForegroundColor(value.UInt32());
+      return true;
+    case kBackgroundColor:
+      if (!value.IsNumber()) {
+        return false;
+      }
+      SetBackgroundColor(value.UInt32());
+      return true;
+    case kDecorationColor:
+      if (!value.IsNumber()) {
+        return false;
+      }
+      SetDecorationColor(value.UInt32());
+      return true;
+    case kDecorationType:
+      if (!value.IsNumber()) {
+        return false;
+      }
+      SetDecorationType(static_cast<DecorationType>(value.Int32()));
+      return true;
+    case kDecorationStyle:
+      if (!value.IsNumber()) {
+        return false;
+      }
+      SetDecorationStyle(static_cast<LineType>(value.Int32()));
+      return true;
+    case kDecorationThicknessMultiplier:
+      if (!value.IsNumber()) {
+        return false;
+      }
+      SetDecorationThicknessMultiplier(value.Float());
+      return true;
+    case kTextStrokeStyle:
+      if (!value.IsNumber()) {
+        return false;
+      }
+      SetTextStrokeValue(value.UInt64());
+      return true;
+    case kBold:
+      if (!value.IsBoolean()) {
+        return false;
+      }
+      SetBold(value.Bool());
+      return true;
+    case kItalic:
+      if (!value.IsBoolean()) {
+        return false;
+      }
+      SetItalic(value.Bool());
+      return true;
+    case kTextShadowList:
+      if (!value.IsPointer() || value.Pointer() == 0 ||
+          value.length != sizeof(TextShadowList)) {
+        return false;
+      }
+      SetTextShadowList(
+          *reinterpret_cast<const TextShadowList*>(value.Pointer()));
+      return true;
+    case kForegroundPainter:
+      if (!value.IsPointer()) {
+        return false;
+      }
+      SetForegroundPainter(reinterpret_cast<Painter*>(value.Pointer()));
+      return true;
+    case kBackgroundPainter:
+      if (!value.IsPointer()) {
+        return false;
+      }
+      SetBackgroundPainter(reinterpret_cast<Painter*>(value.Pointer()));
+      return true;
+    case kWordBreak:
+      if (!value.IsNumber()) {
+        return false;
+      }
+      SetWordBreak(static_cast<WordBreakType>(value.Int32()));
+      return true;
+    case kBaselineOffset:
+      if (!value.IsNumber()) {
+        return false;
+      }
+      SetBaselineOffset(value.Float());
+      return true;
+    case kTextSkew:
+      if (!value.IsNumber()) {
+        return false;
+      }
+      SetTextSkew(value.Float());
+      return true;
+    case kDecorationElementLength:
+      if (!value.IsNumber()) {
+        return false;
+      }
+      SetDecorationElementLength(value.Float());
+      return true;
+    case kDecorationGapLength:
+      if (!value.IsNumber()) {
+        return false;
+      }
+      SetDecorationGapLength(value.Float());
+      return true;
+    case kDecorationSideMargin:
+      if (!value.IsNumber()) {
+        return false;
+      }
+      SetDecorationSideMargin(value.Float());
+      return true;
+    case kDecorationOffset:
+      if (!value.IsNumber()) {
+        return false;
+      }
+      decoration_offset_ = value.Float();
+      flag_ |= DecorationOffsetFlag;
+      return true;
+    default:
+      return false;
+  }
+}
+
+StyleValue Style::GetAttribute(AttributeType attribute) const {
+  StyleValue value;
+  GetAttribute(attribute, &value);
+  return value;
+}
+
+bool Style::GetAttribute(AttributeType attribute, StyleValue* value) const {
+  if (value == nullptr) {
+    return false;
+  }
+
+  switch (attribute) {
+    case kFontDescriptor:
+      *value = StyleValue(&font_descriptor_, sizeof(FontDescriptor));
+      return true;
+    case kTextSize:
+      *value = StyleValue(GetTextSize());
+      return true;
+    case kTextScale:
+      *value = StyleValue(GetTextScale());
+      return true;
+    case kVerticalAlignment:
+      *value = StyleValue(static_cast<int32_t>(GetVerticalAlignment()));
+      return true;
+    case kWordSpacing:
+      *value = StyleValue(GetWordSpacing());
+      return true;
+    case kLetterSpacing:
+      *value = StyleValue(GetLetterSpacing());
+      return true;
+    case kForegroundColor:
+      *value = StyleValue(GetForegroundColor().GetPlainColor());
+      return true;
+    case kBackgroundColor:
+      *value = StyleValue(GetBackgroundColor().GetPlainColor());
+      return true;
+    case kDecorationColor:
+      *value = StyleValue(GetDecorationColor().GetPlainColor());
+      return true;
+    case kDecorationType:
+      *value = StyleValue(static_cast<int32_t>(GetDecorationType()));
+      return true;
+    case kDecorationStyle:
+      *value = StyleValue(static_cast<int32_t>(GetDecorationStyle()));
+      return true;
+    case kDecorationThicknessMultiplier:
+      *value = StyleValue(GetDecorationThicknessMultiplier());
+      return true;
+    case kTextStrokeStyle:
+      *value = StyleValue(GetTextStrokeValue());
+      return true;
+    case kBold:
+      *value = StyleValue(GetBold());
+      return true;
+    case kItalic:
+      *value = StyleValue(GetItalic());
+      return true;
+    case kTextShadowList:
+      *value = StyleValue(&text_shadow_list_, sizeof(TextShadowList));
+      return true;
+    case kForegroundPainter:
+      *value = StyleValue(GetForegroundPainter());
+      return true;
+    case kBackgroundPainter:
+      *value = StyleValue(GetBackgroundPainter());
+      return true;
+    case kWordBreak:
+      *value = StyleValue(static_cast<int32_t>(GetWordBreak()));
+      return true;
+    case kBaselineOffset:
+      *value = StyleValue(GetBaselineOffset());
+      return true;
+    case kTextSkew:
+      *value = StyleValue(GetTextSkew());
+      return true;
+    case kDecorationElementLength:
+      *value = StyleValue(GetDecorationElementLength());
+      return true;
+    case kDecorationGapLength:
+      *value = StyleValue(GetDecorationGapLength());
+      return true;
+    case kDecorationSideMargin:
+      *value = StyleValue(GetDecorationSideMargin());
+      return true;
+    case kDecorationOffset:
+      *value = StyleValue(decoration_offset_);
+      return true;
+    default:
+      *value = StyleValue();
+      return false;
+  }
 }
 }  // namespace tttext
 }  // namespace ttoffice

--- a/src/textlayout/style/style_manager.cc
+++ b/src/textlayout/style/style_manager.cc
@@ -219,6 +219,10 @@ void StyleManager::SetStyle(Style* style, uint64_t value,
       return style->SetDecorationGapLength(UnPackValue<float>(value));
     case AttributeType::kDecorationSideMargin:
       return style->SetDecorationSideMargin(UnPackValue<float>(value));
+    case AttributeType::kDecorationOffset:
+      style->SetAttribute(kDecorationOffset,
+                          StyleValue(UnPackValue<float>(value)));
+      return;
     case AttributeType::kTextStrokeStyle:
       return style->SetTextStrokeValue(value);
     case AttributeType::kBold:
@@ -263,6 +267,8 @@ AttributesRangeList::ValueType StyleManager::GetStyleValue(
       return PackValue(style->GetDecorationGapLength());
     case AttributeType::kDecorationSideMargin:
       return PackValue(style->GetDecorationSideMargin());
+    case AttributeType::kDecorationOffset:
+      return PackValue(style->GetAttribute(kDecorationOffset).Float());
     case AttributeType::kTextStrokeStyle:
       return style->GetTextStrokeValue();
     case AttributeType::kBold:

--- a/src/textlayout/style/style_manager.h
+++ b/src/textlayout/style/style_manager.h
@@ -238,6 +238,21 @@ class StyleManager {
                : UnPackValue<float>(value);
   }
 
+  void SetDecorationOffset(const float attr, const uint32_t start,
+                           const uint32_t len = 1) {
+    constexpr auto max_end = Range::MaxIndex();
+    const auto end = len > max_end - start ? max_end : start + len;
+    style_list_[kDecorationOffset].SetRangeValue(Range{start, end},
+                                                 PackValue(attr));
+  }
+
+  float GetDecorationOffset(const uint32_t idx) const {
+    const auto value = style_list_[kDecorationOffset].GetAttrValue(idx);
+    return value == AttributesRangeList::Undefined()
+               ? default_style_.GetAttribute(kDecorationOffset).Float()
+               : UnPackValue<float>(value);
+  }
+
   void SetForegroundPainter(const Painter* attr, const uint32_t start,
                             const uint32_t len = 1) {
     constexpr auto max_end = Range::MaxIndex();

--- a/test/layout_drawer_test.cc
+++ b/test/layout_drawer_test.cc
@@ -110,6 +110,44 @@ TEST(LayoutDrawer, DrawLayoutPage_TextWithUnderline) {
   drawer.DrawLayoutPage(page.get());
 }
 
+TEST(LayoutDrawer, DrawLayoutPage_TextWithUnderlineUsesDecorationOffset) {
+  // Arrange
+  const float width = 100.f;
+  const float height = 100.f;
+  const char* text = "Hello World!";
+  const float decoration_offset = -4.f;
+  ParagraphImpl para;
+  Style style;
+  style.SetTextSize(1.f);
+  style.SetDecorationType(DecorationType::kUnderLine);
+  style.SetDecorationStyle(LineType::kSolid);
+  style.SetDecorationColor(TTColor::BLACK);
+  style.SetAttribute(kDecorationOffset, StyleValue(decoration_offset));
+  para.AddTextRun(&style, text);
+  TTTextContext context;
+  std::unique_ptr<LayoutRegion> page =
+      std::make_unique<LayoutRegion>(width, height);
+  TextLayout layout(TestUtils::getTestShaper());
+  layout.Layout(&para, page.get(), context);
+  ASSERT_GT(page->GetLineCount(), 0u);
+  TextLine* text_line = page->GetLine(0);
+  ASSERT_NE(text_line, nullptr);
+
+  // Assert
+  NiceMock<MockCanvasHelper> canvas_helper;
+  LayoutDrawer drawer(&canvas_helper);
+  EXPECT_CALL(canvas_helper, CreatePainter()).WillRepeatedly(Invoke([]() {
+    return std::make_unique<Painter>();
+  }));
+  const float expected_y = text_line->GetLineBottom() + decoration_offset;
+  EXPECT_CALL(canvas_helper,
+              DrawLine(_, FloatEq(expected_y), _, FloatEq(expected_y), _))
+      .Times(1);
+
+  // Act
+  drawer.DrawLayoutPage(page.get());
+}
+
 TEST(LayoutDrawer,
      DrawLayoutPage_TextWithDashedUnderlineUsesDecorationLengths) {
   // Arrange

--- a/test/style_manager_test.cc
+++ b/test/style_manager_test.cc
@@ -295,6 +295,15 @@ TEST(StyleManager, AttributeGettersAndSetters) {
   EXPECT_EQ(manager.GetDecorationSideMargin(5), side_margin);
   EXPECT_EQ(manager.GetDecorationSideMargin(6),
             default_style.GetDecorationSideMargin());
+  // Test DecorationOffset
+  const float decoration_offset = -4.f;
+  manager.SetDecorationOffset(decoration_offset, 1, 5);
+  EXPECT_EQ(manager.GetDecorationOffset(0),
+            default_style.GetAttribute(kDecorationOffset).Float());
+  EXPECT_EQ(manager.GetDecorationOffset(1), decoration_offset);
+  EXPECT_EQ(manager.GetDecorationOffset(5), decoration_offset);
+  EXPECT_EQ(manager.GetDecorationOffset(6),
+            default_style.GetAttribute(kDecorationOffset).Float());
   // Test ForegroundPainter
   Painter fg_painter;
   manager.SetForegroundPainter(&fg_painter, 1, 5);
@@ -355,12 +364,14 @@ TEST(StyleManager, GetStyle) {
   const float element_length = 4.f;
   const float gap_length = 2.f;
   const float side_margin = 1.f;
+  const float decoration_offset = -4.f;
   manager.SetForegroundColor(fg_color, 1, 5);
   manager.SetBackgroundColor(bg_color, 1, 5);
   manager.SetDecorationStyle(line_type, 1, 5);
   manager.SetDecorationElementLength(element_length, 1, 5);
   manager.SetDecorationGapLength(gap_length, 1, 5);
   manager.SetDecorationSideMargin(side_margin, 1, 5);
+  manager.SetDecorationOffset(decoration_offset, 1, 5);
 
   Style style = manager.GetStyle(3);
   EXPECT_EQ(style.GetForegroundColor(), fg_color);
@@ -369,6 +380,7 @@ TEST(StyleManager, GetStyle) {
   EXPECT_EQ(style.GetDecorationElementLength(), element_length);
   EXPECT_EQ(style.GetDecorationGapLength(), gap_length);
   EXPECT_EQ(style.GetDecorationSideMargin(), side_margin);
+  EXPECT_EQ(style.GetAttribute(kDecorationOffset).Float(), decoration_offset);
 }
 
 TEST(StyleManager, ApplyStyleInRange) {

--- a/test/style_test.cc
+++ b/test/style_test.cc
@@ -88,3 +88,91 @@ TEST(StyleTest, Reset) {
   style.Reset();
   EXPECT_FALSE(style.HasStyleAttribute(Style::BackgroundColorFlag));
 }
+
+TEST(StyleTest, GenericAttributeSetterGetter) {
+  Style style;
+
+  EXPECT_TRUE(style.SetAttribute(kTextSize, StyleValue(18.f)));
+  StyleValue value;
+  EXPECT_TRUE(style.GetAttribute(kTextSize, &value));
+  EXPECT_EQ(value.type, kStyleValueFloat);
+  EXPECT_TRUE(value.IsNumber());
+  EXPECT_TRUE(ttoffice::FloatsEqual(value.Float(), 18.f));
+  EXPECT_TRUE(style.HasStyleAttribute(Style::TextSizeFlag));
+
+  StyleValue int_value(static_cast<int32_t>(20));
+  EXPECT_TRUE(int_value.IsNumber());
+  EXPECT_EQ(int_value.Int32(), 20);
+  EXPECT_TRUE(ttoffice::FloatsEqual(int_value.Float(), 20.f));
+  EXPECT_TRUE(style.SetAttribute(kTextSize, int_value));
+  EXPECT_TRUE(ttoffice::FloatsEqual(style.GetTextSize(), 20.f));
+
+  EXPECT_TRUE(style.SetAttribute(kForegroundColor, StyleValue(TTColor::RED)));
+  value = style.GetAttribute(kForegroundColor);
+  EXPECT_EQ(value.type, kStyleValueInt64);
+  EXPECT_EQ(value.UInt32(), TTColor::RED);
+  EXPECT_EQ(style.GetForegroundColor(), TTColor::RED);
+
+  EXPECT_TRUE(style.SetAttribute(
+      kDecorationStyle, StyleValue(static_cast<int32_t>(LineType::kDashed))));
+  EXPECT_EQ(style.GetDecorationStyle(), LineType::kDashed);
+
+  Painter painter;
+  EXPECT_TRUE(style.SetAttribute(kForegroundPainter, StyleValue(&painter)));
+  value = style.GetAttribute(kForegroundPainter);
+  EXPECT_TRUE(value.IsPointer());
+  EXPECT_EQ(value.Pointer(), reinterpret_cast<intptr_t>(&painter));
+  EXPECT_EQ(style.GetForegroundPainter(), &painter);
+
+  const uint64_t stroke_value = Style::DefaultStyle().GetTextStrokeValue();
+  EXPECT_TRUE(style.SetAttribute(kTextStrokeStyle, StyleValue(stroke_value)));
+  EXPECT_EQ(style.GetTextStrokeValue(), stroke_value);
+
+  EXPECT_TRUE(style.SetAttribute(kBold, StyleValue(true)));
+  value = style.GetAttribute(kBold);
+  EXPECT_TRUE(value.IsBoolean());
+  EXPECT_TRUE(value.Bool());
+}
+
+TEST(StyleTest, GenericAttributeCopiesObjectValue) {
+  FontDescriptor font_descriptor{{"test"}, FontStyle::Bold(), 1};
+  Style style;
+
+  EXPECT_TRUE(style.SetAttribute(
+      kFontDescriptor, StyleValue(&font_descriptor, sizeof(FontDescriptor))));
+  font_descriptor.platform_font_ = 2;
+
+  EXPECT_EQ(style.GetFontDescriptor().platform_font_, 1u);
+
+  StyleValue value = style.GetAttribute(kFontDescriptor);
+  EXPECT_EQ(value.type, kStyleValuePointer);
+  EXPECT_EQ(value.length, static_cast<int64_t>(sizeof(FontDescriptor)));
+  const auto* stored_font_descriptor =
+      reinterpret_cast<const FontDescriptor*>(value.Pointer());
+  EXPECT_EQ(*stored_font_descriptor, style.GetFontDescriptor());
+}
+
+TEST(StyleTest, GenericAttributeRejectsWrongValueType) {
+  Style style;
+
+  EXPECT_FALSE(style.SetAttribute(kTextSize, StyleValue(true)));
+  EXPECT_FALSE(style.HasStyleAttribute(Style::TextSizeFlag));
+  EXPECT_TRUE(ttoffice::FloatsEqual(style.GetTextSize(),
+                                    Style::DefaultStyle().GetTextSize()));
+
+  StyleValue value;
+  EXPECT_FALSE(style.GetAttribute(kExtraBaselineOffset, &value));
+  EXPECT_FALSE(value.IsValid());
+  EXPECT_FALSE(style.GetAttribute(kTextSize, nullptr));
+}
+
+TEST(StyleTest, CopyKeepsDecorationOffsetFromGenericAttribute) {
+  Style style;
+  style.SetAttribute(kDecorationOffset, StyleValue(-4.f));
+
+  Style copy = style;
+
+  EXPECT_TRUE(copy.HasStyleAttribute(Style::DecorationOffsetFlag));
+  EXPECT_TRUE(ttoffice::FloatsEqual(
+      copy.GetAttribute(kDecorationOffset).Float(), -4.f));
+}


### PR DESCRIPTION
Add decoration offset to Style and StyleManager so underline position can be customized per range. Use the configured offset when drawing underlines, keep the default value aligned with previous behavior, and add JSON parser support plus unit coverage.