### PR TITLE
[Lynxtron] Adapt textlayout public dependency sync

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -5,8 +5,6 @@ system = platform.system().lower()
 machine = platform.machine().lower()
 machine = "x86_64" if machine == "amd64" else machine
 
-root_dir = os.getcwd()
-
 deps = {
     "tools_shared": {
         "type": "solution",
@@ -19,9 +17,7 @@ deps = {
         'type': 'git',
         'url': 'https://github.com/harfbuzz/harfbuzz',
         'commit': 'a070f9ebbe88dc71b248af9731dd49ec93f4e6e6',
-        'patches': [
-            os.path.join(root_dir, 'patches', 'harfbuzz', '*.patch')
-        ],
+        'patches': os.path.join(root_dir, 'patches', 'harfbuzz', '*.patch'),
         "ignore_in_git": True,
     },
     'third_party/icu': {
@@ -128,7 +124,7 @@ deps = {
         "url": "https://github.com/lynx-family/buildroot.git",
         "commit": "79446975604356f28b44c4e67851b3c9aafa372f",
         "ignore_in_git": True,
-        "condition": system in ['linux', 'darwin', 'windows']
+        "condition": False
     },
     'third_party/libcxx': {
         "type": "git",

--- a/DEPS
+++ b/DEPS
@@ -38,30 +38,35 @@ deps = {
         "commit": "705ceef0ec7ab825358e747c76bba6f964424023",
         "deps_file": "hab/DEPS",
         "ignore_in_git": True,
+        "condition": False,
     },
     "third_party/skity/third_party/libjpeg-turbo": {
         "type": "git",
         "url": "https://github.com/libjpeg-turbo/libjpeg-turbo.git",
         "ignore_in_git": True,
         "commit": "f29eda648547b36aa594c4116c7764a6c8a079b9",
+        "condition": False,
     },
     "third_party/skity/third_party/wuffs": {
         "type": "git",
         "url": "https://github.com/google/wuffs-mirror-release-c.git",
         "ignore_in_git": True,
         "commit": "a29749ebe0be57d2b19d8406475bd2326d0f1a85",
+        "condition": False,
     },
     "third_party/skity/third_party/libwebp": {
         "type": "git",
         "url": "https://github.com/webmproject/libwebp.git",
         "ignore_in_git": True,
-        "commit": "4fa21912338357f89e4fd51cf2368325b59e9bd9"
+        "commit": "4fa21912338357f89e4fd51cf2368325b59e9bd9",
+        "condition": False,
     },
     "third_party/skity/third_party/pugixml": {
         "type": "git",
         "url": "https://github.com/zeux/pugixml.git",
         "ignore_in_git": True,
         "commit": "ee86beb30e4973f5feffe3ce63bfa4fbadf72f38",
+        "condition": False,
     },
     'third_party/rapidjson': {
         'type': 'git',

--- a/config.gni
+++ b/config.gni
@@ -12,13 +12,8 @@ if (target_cpu == "arm" || target_cpu == "arm64") {
 # global configs
 declare_args() {
   use_lru_cache = true
-
-  enable_unittests = false
-
   # select linebreak mode between "simple" and "icu"
   boundary_analyst = "simple"
-  enable_16kb_align = false
-  
   # Whether to dynamically load (dlopen) Harfbuzz .so
   dynamic_load_harfbuzz = false
   is_lvgl = false


### PR DESCRIPTION
## Summary

This PR carries the lynx-textra dependency-sync changes needed by Lynxtron public Skity builds:

- prevent lynx-textra's nested Skity dependency sync when Lynxtron already owns the Skity checkout
- prevent the standalone buildroot dependency from being pulled in the Lynxtron public integration path
- remove unused GN args that conflicted with the Lynxtron public GN generation path
- keep existing harfbuzz patch application behavior while simplifying the patch path expression

## Impact

This is the most dependency-flow-sensitive of the three upstream PRs. It changes `DEPS` conditions and `config.gni`, so maintainers should confirm whether the conditions should remain unconditional or be gated by a Lynxtron-specific integration flag before this becomes non-draft. The intended impact is to avoid duplicate Skity/buildroot ownership in Lynxtron; it should not be treated as a generic lynx-textra standalone behavior change without review.

## Validation

Validated from the Lynxtron integration branch:

- public standalone `lynxtron/lynxtron` dependency sync pulls this lynx-textra commit
- nested Skity sync from lynx-textra is skipped in the Lynxtron public integration path
- public GN/build with Skity succeeds
- `ninja -C out/Debug lynxtron_app`
- `out/Debug/lynxtron.app/Contents/MacOS/lynxtron --version` -> `v1.0.0`
