### PR TITLE
BugFix] guard boundary analyst against out-of-bounds access

### DIFF
--- a/src/textlayout/internal/boundary_analyst.cc
+++ b/src/textlayout/internal/boundary_analyst.cc
@@ -6,6 +6,7 @@
 
 #include <textra/macro.h>
 
+#include <algorithm>
 #include <memory>
 #include <string>
 #ifdef BOUNDARY_ANALYST_ICU
@@ -114,6 +115,10 @@ BoundaryAnalyst::BoundaryAnalyst(const char32_t* u32_content,
                                  LineBreakStrategy line_break_strategy) {
   // runs are left-closed right-open intervals, the last charpos of text is \0
   // character
+  if (u32_content == nullptr || char_count == 0) {
+    boundary_.resize(char_count, BoundaryType::kLineBreakable);
+    return;
+  }
 #ifdef BOUNDARY_ANALYST_ICU
   boundary_.resize(char_count, BoundaryType::kNone);
   auto& icu_wrapper = ICUWrapper::GetInstance();
@@ -133,6 +138,7 @@ uint32_t BoundaryAnalyst::FindNextBoundary(uint32_t start,
 }
 uint32_t BoundaryAnalyst::FindPrevBoundary(uint32_t start,
                                            BoundaryType type) const {
+  start = std::min(start, static_cast<uint32_t>(boundary_.size()));
   for (auto k = start; k > 0; --k) {
     if (GetBoundaryTypeBefore(k) >= type) return k;
   }

--- a/src/textlayout/internal/boundary_analyst.h
+++ b/src/textlayout/internal/boundary_analyst.h
@@ -5,7 +5,6 @@
 #ifndef SRC_TEXTLAYOUT_INTERNAL_BOUNDARY_ANALYST_H_
 #define SRC_TEXTLAYOUT_INTERNAL_BOUNDARY_ANALYST_H_
 #include <textra/layout_definition.h>
-#include <textra/macro.h>
 
 #include <vector>
 
@@ -23,11 +22,12 @@ class BoundaryAnalyst {
   uint32_t FindNextBoundary(uint32_t start, BoundaryType type) const;
   uint32_t FindPrevBoundary(uint32_t start, BoundaryType type) const;
   BoundaryType GetBoundaryTypeBefore(uint32_t idx) const {
-    return idx == 0 ? BoundaryType::kLineBreakable : boundary_[idx - 1];
+    return idx == 0 || idx > boundary_.size() ? BoundaryType::kLineBreakable
+                                              : boundary_[idx - 1];
   }
   BoundaryType GetBoundaryType(uint32_t idx) const {
-    TTASSERT(idx < boundary_.size());
-    return boundary_[idx];
+    return idx < boundary_.size() ? boundary_[idx]
+                                  : BoundaryType::kLineBreakable;
   }
   void UpgradeBoundaryType(const Range& range, BoundaryType type);
 

--- a/test/boundary_analyst_test.cc
+++ b/test/boundary_analyst_test.cc
@@ -54,3 +54,37 @@ TEST(BoundaryAnalystTest, DisableAvoidBreakAroundPunctuation) {
               boundary_analyst.GetBoundaryType(i));
   }
 }
+
+TEST(BoundaryAnalystTest, OutOfRangeAccessFallsBackToLineBreakable) {
+  constexpr std::u32string_view text = U"text";
+  const BoundaryAnalyst boundary_analyst(text.data(), text.size(),
+                                         kLineBreakStrategyDefault);
+
+  EXPECT_EQ(BoundaryType::kLineBreakable,
+            boundary_analyst.GetBoundaryType(text.size()));
+  EXPECT_EQ(BoundaryType::kLineBreakable,
+            boundary_analyst.GetBoundaryTypeBefore(text.size() + 1));
+}
+
+TEST(BoundaryAnalystTest, EmptyBoundaryAccessFallsBackToLineBreakable) {
+  const BoundaryAnalyst boundary_analyst(nullptr, 0, kLineBreakStrategyDefault);
+
+  EXPECT_EQ(BoundaryType::kLineBreakable, boundary_analyst.GetBoundaryType(27));
+  EXPECT_EQ(BoundaryType::kLineBreakable,
+            boundary_analyst.GetBoundaryTypeBefore(28));
+  EXPECT_EQ(
+      0u, boundary_analyst.FindNextBoundary(27, BoundaryType::kLineBreakable));
+  EXPECT_EQ(
+      0u, boundary_analyst.FindPrevBoundary(28, BoundaryType::kLineBreakable));
+}
+
+TEST(BoundaryAnalystTest, NullContentUsesSafeFallbackBoundaries) {
+  constexpr uint32_t kCharCount = 28;
+  const BoundaryAnalyst boundary_analyst(nullptr, kCharCount,
+                                         kLineBreakStrategyDefault);
+
+  EXPECT_EQ(BoundaryType::kLineBreakable,
+            boundary_analyst.GetBoundaryType(kCharCount - 1));
+  EXPECT_EQ(kCharCount, boundary_analyst.FindPrevBoundary(
+                            kCharCount + 1, BoundaryType::kLineBreakable));
+}


### PR DESCRIPTION
- handle null and empty text inputs safely
- return fallback boundaries for invalid indices
- clamp backward boundary searches to the valid range
- add regression tests for invalid access