### PR TITLE
[Feature] Support ordered font-family fallback in self-rendering CoreText

### DIFF
--- a/LynxTextra.podspec
+++ b/LynxTextra.podspec
@@ -111,6 +111,8 @@ Pod::Spec.new do |s|
                                 "src/ports/platform_helper.cc",
                                 "src/ports/shaper/coretext/shaper_core_text.h",
                                 "src/ports/shaper/coretext/shaper_core_text.mm",
+                                "src/ports/shaper/coretext/shaper_core_text_self_rendering.h",
+                                "src/ports/shaper/coretext/shaper_core_text_self_rendering.mm",
                                 "src/textlayout/dominate_baseline.cc",
                                 "src/textlayout/dominate_baseline.h",
                                 "src/textlayout/font_info.cc",

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -303,6 +303,8 @@ source_set("textlayout") {
     sources += [
       "$prj_root/src/ports/shaper/coretext/shaper_core_text.h",
       "$prj_root/src/ports/shaper/coretext/shaper_core_text.mm",
+      "$prj_root/src/ports/shaper/coretext/shaper_core_text_self_rendering.h",
+      "$prj_root/src/ports/shaper/coretext/shaper_core_text_self_rendering.mm",
     ]
 
     cflags_objc = [ "-fobjc-arc" ]

--- a/src/ports/shaper/coretext/shaper_core_text_self_rendering.h
+++ b/src/ports/shaper/coretext/shaper_core_text_self_rendering.h
@@ -1,0 +1,121 @@
+// Copyright 2022 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#ifndef SRC_PORTS_SHAPER_CORETEXT_SHAPER_CORE_TEXT_SELF_RENDERING_H_
+#define SRC_PORTS_SHAPER_CORETEXT_SHAPER_CORE_TEXT_SELF_RENDERING_H_
+
+#import <CoreFoundation/CoreFoundation.h>
+#import <CoreText/CoreText.h>
+#include <textra/text_layout.h>
+
+#include <cstddef>
+#include <list>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "src/textlayout/tt_shaper.h"
+
+namespace ttoffice {
+namespace tttext {
+class RunStyle;
+constexpr uint32_t SELF_RENDERING_SHAPER_BUFF_SIZE = 1024;
+
+// CoreText shaper for callers that render the returned glyphs themselves.
+// This class deliberately forks ShaperCoreText so ordered web-font matching
+// cannot change the legacy kSystem path. Keep its cache state independent as
+// well: custom typefaces can be app-owned even though CoreText registration is
+// process-wide.
+class ShaperCoreTextSelfRendering : public TTShaper {
+  friend class ShaperCoreTextSelfRenderingTestAccess;
+
+ public:
+  ShaperCoreTextSelfRendering() = delete;
+  explicit ShaperCoreTextSelfRendering(
+      FontmgrCollection& font_collections) noexcept;
+  ~ShaperCoreTextSelfRendering() override;
+
+ public:
+  void ProcessBidirection(const char32_t* text, uint32_t length,
+                          WriteDirection write_direction, uint32_t* visual_map,
+                          uint32_t* logical_map, uint8_t* dir_vec) override;
+  void OnShapeText(const ShapeKey& key, ShapeResult* result) const override;
+  static void SetSafeFontCacheMaxEntries(size_t max_entries);
+  static size_t GetSafeFontCacheMaxEntries();
+
+ private:
+  static CTFontDescriptorRef CopyFontDescriptorWithoutCascade(
+      CTFontDescriptorRef font_descriptor);
+  static CFArrayRef CreateOrderedCascadeDescriptors(
+      const std::vector<CTFontDescriptorRef>& font_descriptors);
+  static bool FontCoversStringRangeExactly(CTFontRef font, CFStringRef string,
+                                           CFRange range);
+
+  struct CachedSafeFontKey {
+    FontDescriptor font_descriptor_;
+    float text_size_ = 0.0f;
+    bool fake_bold_ = false;
+    bool fake_italic_ = false;
+
+    struct Hasher {
+      size_t operator()(const CachedSafeFontKey& key) const {
+        size_t seed = 0;
+        const auto hash_combine = [&seed](size_t value) {
+          seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+        };
+        for (const auto& family : key.font_descriptor_.font_family_list_) {
+          hash_combine(std::hash<std::string>()(family));
+        }
+        hash_combine(
+            std::hash<int32_t>()(key.font_descriptor_.font_style_.Value()));
+        hash_combine(
+            std::hash<uint64_t>()(key.font_descriptor_.platform_font_));
+        hash_combine(std::hash<float>()(key.text_size_));
+        hash_combine(std::hash<bool>()(key.fake_bold_));
+        hash_combine(std::hash<bool>()(key.fake_italic_));
+        return seed;
+      }
+    };
+
+    bool operator==(const CachedSafeFontKey& rhs) const {
+      return font_descriptor_ == rhs.font_descriptor_ &&
+             text_size_ == rhs.text_size_ && fake_bold_ == rhs.fake_bold_ &&
+             fake_italic_ == rhs.fake_italic_;
+    }
+  };
+
+  struct CachedSafeFontEntry {
+    CTFontRef safe_font_ = nullptr;
+    std::list<CachedSafeFontKey>::iterator lru_it_;
+  };
+
+  CFAttributedStringRef GenerateAttributeString(const char16_t* content,
+                                                uint32_t length,
+                                                uint32_t* u16char_map,
+                                                CFDictionaryRef key) const;
+  CFDictionaryRef GenerateAttributes(const ShapeKey& key) const;
+  void ApplyOrderedFamilyFonts(
+      CFMutableAttributedStringRef attributed_string, float text_size,
+      const std::vector<TypefaceRef>& resolved_typefaces) const;
+  CTFontRef CreateSafeFontWithOrderedFamilyList(
+      CTFontRef existing_font,
+      const std::vector<TypefaceRef>& resolved_typefaces) const;
+  CTFontRef GetOrCreateSafeFont(const FontDescriptor& fd, float text_size,
+                                bool fake_bold, bool fake_italic) const;
+  static void TrimSafeFontCacheLocked();
+
+ private:
+  mutable std::vector<TypefaceRef> ct_font_lst_;
+  mutable uint32_t tmp_buf_[SELF_RENDERING_SHAPER_BUFF_SIZE];
+  static std::unordered_map<CachedSafeFontKey, CachedSafeFontEntry,
+                            CachedSafeFontKey::Hasher>
+      safe_font_cache_;
+  static std::list<CachedSafeFontKey> safe_font_cache_lru_;
+  static std::mutex safe_font_cache_mutex_;
+  static size_t safe_font_cache_max_entries_;
+};
+}  // namespace tttext
+}  // namespace ttoffice
+#endif  // SRC_PORTS_SHAPER_CORETEXT_SHAPER_CORE_TEXT_SELF_RENDERING_H_

--- a/src/ports/shaper/coretext/shaper_core_text_self_rendering.mm
+++ b/src/ports/shaper/coretext/shaper_core_text_self_rendering.mm
@@ -1,0 +1,760 @@
+// Copyright 2025 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "shaper_core_text_self_rendering.h"
+
+#ifndef MIN
+#import <objc/NSObjCRuntime.h>
+#endif
+
+#if TARGET_OS_IOS
+#define USE_UIKIT
+#elif TARGET_OS_MAC
+#define USE_APPKIT
+#endif
+
+#ifdef USE_UIKIT
+#import <UIKit/UIKit.h>
+#endif
+
+#ifdef USE_APPKIT
+#import <AppKit/AppKit.h>
+#endif
+
+#include <textra/font_info.h>
+#include <textra/fontmgr_collection.h>
+#include <textra/i_canvas_helper.h>
+#include <textra/style.h>
+
+#include <algorithm>
+
+#include "src/textlayout/utils/grapheme_utils.h"
+#include "src/textlayout/utils/u_8_string.h"
+
+namespace ttoffice {
+namespace tttext {
+std::unordered_map<ShaperCoreTextSelfRendering::CachedSafeFontKey,
+                   ShaperCoreTextSelfRendering::CachedSafeFontEntry,
+                   ShaperCoreTextSelfRendering::CachedSafeFontKey::Hasher>
+    ShaperCoreTextSelfRendering::safe_font_cache_;
+std::list<ShaperCoreTextSelfRendering::CachedSafeFontKey>
+    ShaperCoreTextSelfRendering::safe_font_cache_lru_;
+std::mutex ShaperCoreTextSelfRendering::safe_font_cache_mutex_;
+size_t ShaperCoreTextSelfRendering::safe_font_cache_max_entries_ = 256;
+
+namespace {
+
+void AppendSafeFontCascadeDescriptors(CFMutableArrayRef descriptors) {
+  const CFStringRef fallback_names[] = {
+      CFSTR("PingFang SC"),        // Simplified Chinese
+      CFSTR("Apple Color Emoji"),  // Emoji & Symbols
+      CFSTR("Thonburi"),           // Thai
+      CFSTR("Geeza Pro")           // Arabic
+  };
+  const CFIndex count = sizeof(fallback_names) / sizeof(fallback_names[0]);
+  for (CFIndex i = 0; i < count; ++i) {
+    CTFontDescriptorRef descriptor =
+        CTFontDescriptorCreateWithNameAndSize(fallback_names[i], 0.0);
+    if (descriptor != nullptr) {
+      CFArrayAppendValue(descriptors, descriptor);
+      CFRelease(descriptor);
+    }
+  }
+}
+
+static float ConvertFontWeight(tttext::Weight weight) {
+#ifdef USE_APPKIT
+  switch (weight) {
+    case FontStyle::kThin_Weight:
+      return NSFontWeightUltraLight;
+    case FontStyle::kExtraLight_Weight:
+      return NSFontWeightThin;
+    case FontStyle::kLight_Weight:
+      return NSFontWeightLight;
+    case FontStyle::kNormal_Weight:
+      return NSFontWeightRegular;
+    case FontStyle::kMedium_Weight:
+      return NSFontWeightMedium;
+    case FontStyle::kSemiBold_Weight:
+      return NSFontWeightSemibold;
+    case FontStyle::kBold_Weight:
+      return NSFontWeightBold;
+    case FontStyle::kExtraBold_Weight:
+      return NSFontWeightHeavy;
+    case FontStyle::kBlack_Weight:
+      return NSFontWeightBlack;
+    default:
+      return NSFontWeightRegular;
+  }
+#endif
+#ifdef USE_UIKIT
+  switch (weight) {
+    case FontStyle::kThin_Weight:
+      return UIFontWeightUltraLight;
+    case FontStyle::kExtraLight_Weight:
+      return UIFontWeightThin;
+    case FontStyle::kLight_Weight:
+      return UIFontWeightLight;
+    case FontStyle::kNormal_Weight:
+      return UIFontWeightRegular;
+    case FontStyle::kMedium_Weight:
+      return UIFontWeightMedium;
+    case FontStyle::kSemiBold_Weight:
+      return UIFontWeightSemibold;
+    case FontStyle::kBold_Weight:
+      return UIFontWeightBold;
+    case FontStyle::kExtraBold_Weight:
+      return UIFontWeightHeavy;
+    case FontStyle::kBlack_Weight:
+      return UIFontWeightBlack;
+    default:
+      return UIFontWeightRegular;
+  }
+#endif
+}
+
+}  // namespace
+
+CTFontDescriptorRef
+ShaperCoreTextSelfRendering::CopyFontDescriptorWithoutCascade(
+    CTFontDescriptorRef font_descriptor) {
+  if (font_descriptor == nullptr) {
+    return nullptr;
+  }
+  CFArrayRef empty_cascade =
+      CFArrayCreate(kCFAllocatorDefault, nullptr, 0, &kCFTypeArrayCallBacks);
+  const void* keys[] = {kCTFontCascadeListAttribute};
+  const void* values[] = {empty_cascade};
+  CFDictionaryRef attributes = CFDictionaryCreate(
+      kCFAllocatorDefault, keys, values, 1, &kCFTypeDictionaryKeyCallBacks,
+      &kCFTypeDictionaryValueCallBacks);
+  CTFontDescriptorRef descriptor =
+      CTFontDescriptorCreateCopyWithAttributes(font_descriptor, attributes);
+  CFRelease(attributes);
+  CFRelease(empty_cascade);
+  return descriptor;
+}
+
+CFArrayRef ShaperCoreTextSelfRendering::CreateOrderedCascadeDescriptors(
+    const std::vector<CTFontDescriptorRef>& font_descriptors) {
+  CFMutableArrayRef cascade =
+      CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
+  for (CTFontDescriptorRef font_descriptor : font_descriptors) {
+    CTFontDescriptorRef descriptor_without_cascade =
+        CopyFontDescriptorWithoutCascade(font_descriptor);
+    if (descriptor_without_cascade != nullptr) {
+      CFArrayAppendValue(cascade, descriptor_without_cascade);
+      CFRelease(descriptor_without_cascade);
+    }
+  }
+  AppendSafeFontCascadeDescriptors(cascade);
+  return cascade;
+}
+
+bool ShaperCoreTextSelfRendering::FontCoversStringRangeExactly(
+    CTFontRef font, CFStringRef string, CFRange range) {
+  if (font == nullptr || string == nullptr || range.length <= 0) {
+    return false;
+  }
+
+  CTFontRef resolved_font = CTFontCreateForString(font, string, range);
+  if (resolved_font == nullptr) {
+    return false;
+  }
+  CFStringRef expected_name = CTFontCopyPostScriptName(font);
+  CFStringRef resolved_name = CTFontCopyPostScriptName(resolved_font);
+  const bool matches = expected_name != nullptr && resolved_name != nullptr &&
+                       CFEqual(expected_name, resolved_name);
+  if (expected_name != nullptr) {
+    CFRelease(expected_name);
+  }
+  if (resolved_name != nullptr) {
+    CFRelease(resolved_name);
+  }
+  CFRelease(resolved_font);
+  return matches;
+}
+
+ShaperCoreTextSelfRendering::ShaperCoreTextSelfRendering(
+    FontmgrCollection& font_collection) noexcept
+    : TTShaper(font_collection){};
+
+ShaperCoreTextSelfRendering::~ShaperCoreTextSelfRendering() = default;
+
+void ShaperCoreTextSelfRendering::SetSafeFontCacheMaxEntries(
+    size_t max_entries) {
+  std::lock_guard<std::mutex> lock(safe_font_cache_mutex_);
+  safe_font_cache_max_entries_ = max_entries;
+  TrimSafeFontCacheLocked();
+}
+
+size_t ShaperCoreTextSelfRendering::GetSafeFontCacheMaxEntries() {
+  std::lock_guard<std::mutex> lock(safe_font_cache_mutex_);
+  return safe_font_cache_max_entries_;
+}
+
+void ShaperCoreTextSelfRendering::TrimSafeFontCacheLocked() {
+  while (safe_font_cache_.size() > safe_font_cache_max_entries_) {
+    const auto& oldest_key = safe_font_cache_lru_.back();
+    auto iter = safe_font_cache_.find(oldest_key);
+    if (iter != safe_font_cache_.end()) {
+      if (iter->second.safe_font_ != nullptr) {
+        CFRelease(iter->second.safe_font_);
+      }
+      safe_font_cache_.erase(iter);
+    }
+    safe_font_cache_lru_.pop_back();
+  }
+}
+
+CTFontRef ShaperCoreTextSelfRendering::CreateSafeFontWithOrderedFamilyList(
+    CTFontRef existing_font,
+    const std::vector<TypefaceRef>& resolved_typefaces) const {
+  if (existing_font == nullptr) {
+    return nullptr;
+  }
+
+  std::vector<CTFontDescriptorRef> fallback_descriptors;
+  auto font_manager = font_collection_.GetDefaultFontManager();
+  if (font_manager != nullptr) {
+    fallback_descriptors.reserve(resolved_typefaces.size());
+    for (size_t i = 1; i < resolved_typefaces.size(); ++i) {
+      CTFontRef font = static_cast<CTFontRef>(
+          font_manager->getPlatformFontFromTypeface(resolved_typefaces[i]));
+      if (font != nullptr) {
+        fallback_descriptors.push_back(CTFontCopyFontDescriptor(font));
+      }
+    }
+  }
+
+  CFArrayRef cascade = CreateOrderedCascadeDescriptors(fallback_descriptors);
+  for (CTFontDescriptorRef descriptor : fallback_descriptors) {
+    CFRelease(descriptor);
+  }
+
+  const void* keys[] = {kCTFontCascadeListAttribute};
+  const void* values[] = {cascade};
+  CFDictionaryRef cascade_attributes = CFDictionaryCreate(
+      kCFAllocatorDefault, keys, values, 1, &kCFTypeDictionaryKeyCallBacks,
+      &kCFTypeDictionaryValueCallBacks);
+
+  CTFontDescriptorRef existing_descriptor =
+      CTFontCopyFontDescriptor(existing_font);
+  CTFontDescriptorRef descriptor_without_cascade =
+      CopyFontDescriptorWithoutCascade(existing_descriptor);
+  CTFontDescriptorRef ordered_descriptor =
+      CTFontDescriptorCreateCopyWithAttributes(descriptor_without_cascade,
+                                               cascade_attributes);
+  CTFontRef ordered_font = CTFontCreateWithFontDescriptor(
+      ordered_descriptor, CTFontGetSize(existing_font), nullptr);
+
+  CFRelease(ordered_descriptor);
+  CFRelease(descriptor_without_cascade);
+  CFRelease(existing_descriptor);
+  CFRelease(cascade_attributes);
+  CFRelease(cascade);
+  return ordered_font;
+}
+
+CTFontRef ShaperCoreTextSelfRendering::GetOrCreateSafeFont(
+    const FontDescriptor& fd, float text_size, bool fake_bold,
+    bool fake_italic) const {
+  CachedSafeFontKey cache_key{fd, text_size, fake_bold, fake_italic};
+  {
+    std::lock_guard<std::mutex> lock(safe_font_cache_mutex_);
+    auto iter = safe_font_cache_.find(cache_key);
+    if (iter != safe_font_cache_.end()) {
+      safe_font_cache_lru_.splice(safe_font_cache_lru_.begin(),
+                                  safe_font_cache_lru_, iter->second.lru_it_);
+      iter->second.lru_it_ = safe_font_cache_lru_.begin();
+      return static_cast<CTFontRef>(CFRetain(iter->second.safe_font_));
+    }
+  }
+
+  CTFontRef base_font = nullptr;
+  std::vector<TypefaceRef> resolved_typefaces;
+  if (fd.platform_font_ != 0) {
+#ifdef USE_APPKIT
+    CTFontRef platform_font =
+        reinterpret_cast<CTFontRef>(static_cast<uintptr_t>(fd.platform_font_));
+    if (platform_font != nullptr) {
+      base_font = CTFontCreateCopyWithAttributes(platform_font, text_size,
+                                                 nullptr, nullptr);
+    }
+#endif
+#ifdef USE_UIKIT
+    UIFont* ui_font = (__bridge UIFont*)((void*)fd.platform_font_);
+    if (ui_font != nullptr) {
+      base_font = (__bridge_retained CTFontRef)
+          [UIFont fontWithDescriptor:ui_font.fontDescriptor size:text_size];
+    }
+#endif
+  } else if (!fd.font_family_list_.empty()) {
+    bool has_valid_font_family = false;
+    for (const auto& font_family : fd.font_family_list_) {
+      if (!font_family.empty()) {
+        has_valid_font_family = true;
+        break;
+      }
+    }
+    if (has_valid_font_family) {
+      resolved_typefaces = font_collection_.findTypefaces(fd);
+      if (!resolved_typefaces.empty()) {
+        auto ct_typeface = static_cast<CTFontRef>(
+            font_collection_.GetDefaultFontManager()
+                ->getPlatformFontFromTypeface(resolved_typefaces[0]));
+        if (ct_typeface != nullptr) {
+          base_font = CTFontCreateCopyWithAttributes(ct_typeface, text_size,
+                                                     nullptr, nullptr);
+        }
+      }
+    }
+  }
+
+  if (base_font == nullptr) {
+#ifdef USE_APPKIT
+    if (fake_bold) {
+      base_font =
+          CTFontCreateWithName(CFSTR("Helvetica-Bold"), text_size, NULL);
+    } else if (fake_italic) {
+      base_font =
+          CTFontCreateWithName(CFSTR("Helvetica-Oblique"), text_size, NULL);
+    } else {
+      base_font = CTFontCreateWithName(CFSTR("Helvetica"), text_size, NULL);
+    }
+#endif
+#ifdef USE_UIKIT
+    CGFloat font_weight = ConvertFontWeight(fd.font_style_.GetWeight());
+    if (fake_bold) {
+      base_font =
+          (__bridge_retained CTFontRef)[UIFont boldSystemFontOfSize:text_size];
+    } else if (fake_italic) {
+      base_font = (__bridge_retained CTFontRef)
+          [UIFont italicSystemFontOfSize:text_size];
+    } else {
+      base_font =
+          (__bridge_retained CTFontRef)[UIFont systemFontOfSize:text_size
+                                                         weight:font_weight];
+    }
+#endif
+  }
+
+  if (base_font == nullptr) {
+    return nullptr;
+  }
+
+  // CSS Fonts 4 requires author-provided families to be visited in declaration
+  // order before system fallback:
+  // https://www.w3.org/TR/css-fonts-4/#font-matching-algorithm. Blink models
+  // that walk in FontFallbackIterator, while WebKit removes nested CoreText
+  // cascades before composing its own ordered list (see
+  // third_party/blink/renderer/platform/fonts/font_fallback_iterator.cc and
+  // Source/WebCore/platform/graphics/cocoa/SystemFontDatabaseCoreText.cpp).
+  // A descriptor with zero or one resolved family naturally produces only the
+  // existing safe fallback list, so ordered matching does not need a separate
+  // legacy branch.
+  CTFontRef safe_font =
+      CreateSafeFontWithOrderedFamilyList(base_font, resolved_typefaces);
+  CFRelease(base_font);
+  if (safe_font == nullptr) {
+    return nullptr;
+  }
+
+  std::lock_guard<std::mutex> lock(safe_font_cache_mutex_);
+  auto iter = safe_font_cache_.find(cache_key);
+  if (iter != safe_font_cache_.end()) {
+    CFRelease(safe_font);
+    safe_font_cache_lru_.splice(safe_font_cache_lru_.begin(),
+                                safe_font_cache_lru_, iter->second.lru_it_);
+    iter->second.lru_it_ = safe_font_cache_lru_.begin();
+    return static_cast<CTFontRef>(CFRetain(iter->second.safe_font_));
+  }
+
+  if (safe_font_cache_max_entries_ == 0) {
+    return safe_font;
+  }
+
+  safe_font_cache_lru_.push_front(cache_key);
+  safe_font_cache_.emplace(
+      cache_key, CachedSafeFontEntry{safe_font, safe_font_cache_lru_.begin()});
+  TrimSafeFontCacheLocked();
+  return static_cast<CTFontRef>(CFRetain(safe_font));
+}
+
+void ShaperCoreTextSelfRendering::ProcessBidirection(
+    const char32_t* text, uint32_t length, WriteDirection write_direction,
+    uint32_t* visual_map, uint32_t* logical_map, uint8_t* dir_vec) {
+  auto u16_str = ttoffice::base::U32StringToU16(text, length);
+  uint32_t* u16_to_u32_map = tmp_buf_;
+  if (u16_str.length() + 1 > SELF_RENDERING_SHAPER_BUFF_SIZE) {
+    u16_to_u32_map = new uint32_t[u16_str.length() + 1];
+  }
+  CTWritingDirection direction = kCTWritingDirectionNatural;
+  if (write_direction == WriteDirection::kLTR ||
+      write_direction == WriteDirection::kTTB) {
+    direction = kCTWritingDirectionLeftToRight;
+  } else if (write_direction == WriteDirection::kRTL ||
+             write_direction == WriteDirection::kBTT) {
+    direction = kCTWritingDirectionRightToLeft;
+  }
+  CFMutableDictionaryRef dict =
+      CFDictionaryCreateMutable(NULL, 0, &kCFTypeDictionaryKeyCallBacks,
+                                &kCFTypeDictionaryValueCallBacks);
+  // --- FIX START ---
+  // Force inject a safe font into the dictionary.
+  // This ensures CTLineCreate has a localized fallback path.
+  FontDescriptor default_fd;
+  CTFontRef safe_font = GetOrCreateSafeFont(default_fd, 12.0, false, false);
+  if (safe_font != nullptr) {
+    CFDictionaryAddValue(dict, kCTFontAttributeName, safe_font);
+    CFRelease(safe_font);
+  }
+  // --- FIX END ---
+
+  CTParagraphStyleRef para_style = NULL;
+  if (direction != kCTWritingDirectionNatural) {
+    CTParagraphStyleSetting setting;
+    setting.spec = kCTParagraphStyleSpecifierBaseWritingDirection;
+    setting.valueSize = sizeof(direction);
+    setting.value = &direction;
+    para_style = CTParagraphStyleCreate(&setting, 1);
+    CFDictionaryAddValue(dict, kCTParagraphStyleAttributeName, para_style);
+  }
+  auto attr_text = GenerateAttributeString(
+      u16_str.data(), static_cast<uint32_t>(u16_str.length()), u16_to_u32_map,
+      dict);
+  auto line = CTLineCreateWithAttributedString(attr_text);
+  CFArrayRef array_ref = CTLineGetGlyphRuns(line);
+  auto array_count = CFArrayGetCount(array_ref);
+
+  int order = 0;
+  for (int run_idx = 0; run_idx < array_count; run_idx++) {
+    CTRunRef run = (CTRunRef)CFArrayGetValueAtIndex(array_ref, run_idx);
+    CFRange range = CTRunGetStringRange(run);
+    auto char_start = u16_to_u32_map[range.location];
+    auto char_end = u16_to_u32_map[range.location + range.length];
+    auto char_count = char_end - char_start;
+    auto run_status = CTRunGetStatus(run);
+    bool is_rtl = static_cast<bool>(run_status & kCTRunStatusRightToLeft);
+    if (is_rtl) {
+      for (long k = char_count - 1; k >= 0; k--) {
+        dir_vec[char_start + k] = 1;
+        visual_map[char_start + k] = static_cast<unsigned int>(order++);
+      }
+    } else {
+      for (long k = 0; k < char_count; k++) {
+        dir_vec[char_start + k] = 0;
+        visual_map[char_start + k] = static_cast<unsigned int>(order++);
+      }
+    }
+  }
+  if (u16_to_u32_map != tmp_buf_) {
+    delete[] u16_to_u32_map;
+  }
+  CFRelease(attr_text);
+  CFRelease(dict);
+  CFRelease(line);
+  if (para_style != NULL) {
+    CFRelease(para_style);
+  }
+}
+
+class CTShapingResult : public PlatformShapingResultReader {
+ public:
+  CTShapingResult(){};
+
+ public:
+  uint32_t GlyphCount() const override {
+    return static_cast<uint32_t>(ct_glyphs_.size());
+  }
+  uint32_t TextCount() const override { return text_length_; }
+  GlyphID ReadGlyphID(uint32_t idx) const override { return ct_glyphs_[idx]; }
+  float ReadAdvanceX(uint32_t idx) const override {
+    return ct_advances_[idx].width;
+  }
+  float ReadAdvanceY(uint32_t idx) const override {
+    return ct_advances_[idx].height;
+  }
+  float ReadPositionX(uint32_t idx) const override {
+    return ct_position_[idx].x;
+  }
+  float ReadPositionY(uint32_t idx) const override {
+    return ct_position_[idx].y;
+  }
+  uint32_t ReadIndices(uint32_t idx) const override {
+    return static_cast<uint32_t>(ct_indices_[idx]);
+  }
+  TypefaceRef ReadFontId(uint32_t idx) const override { return typeface_[idx]; }
+
+  void AppendResult(TypefaceRef typeface, CGGlyph* glyphs, CGSize* advances,
+                    CFIndex* indices, CGPoint* position, int glyph_count,
+                    int char_count, bool is_rtl) {
+    if (is_rtl) {
+      ct_glyphs_.insert(ct_glyphs_.begin(), glyphs, glyphs + glyph_count);
+      ct_advances_.insert(ct_advances_.begin(), advances,
+                          advances + glyph_count);
+      ct_indices_.insert(ct_indices_.begin(), indices, indices + glyph_count);
+      typeface_.insert(typeface_.begin(), glyph_count, typeface);
+      ct_position_.insert(ct_position_.begin(), position,
+                          position + glyph_count);
+    } else {
+      ct_glyphs_.insert(ct_glyphs_.end(), glyphs, glyphs + glyph_count);
+      ct_advances_.insert(ct_advances_.end(), advances, advances + glyph_count);
+      ct_indices_.insert(ct_indices_.end(), indices, indices + glyph_count);
+      typeface_.insert(typeface_.end(), glyph_count, typeface);
+      ct_position_.insert(ct_position_.end(), position, position + glyph_count);
+    }
+    text_length_ += char_count;
+  }
+
+ public:
+  std::vector<CGGlyph> ct_glyphs_;
+  std::vector<CGSize> ct_advances_;
+  std::vector<CFIndex> ct_indices_;
+  std::vector<CGPoint> ct_position_;
+  std::vector<TypefaceRef> typeface_;
+  uint32_t text_length_{0};
+};
+void ShaperCoreTextSelfRendering::OnShapeText(const ShapeKey& key,
+                                              ShapeResult* result) const {
+  CFDictionaryRef attributes = GenerateAttributes(key);
+
+  // CoreText returns platform fonts for each run. Preserve the exact
+  // TypefaceRef resolved by this shape's FontmgrCollection whenever the run
+  // uses one of the declared faces. This mapping is deliberately local to the
+  // shape: custom managers can be app-owned even though CoreText font
+  // registration and Textra's caches are process-wide. Unmatched runs remain
+  // platform fallback and continue through the default-manager path.
+  std::vector<TypefaceRef> resolved_typefaces;
+  std::vector<std::pair<TypefaceRef, CFStringRef>> ordered_typefaces;
+  auto default_font_manager = font_collection_.GetDefaultFontManager();
+  if (default_font_manager != nullptr &&
+      !key.style_.GetFontDescriptor().font_family_list_.empty()) {
+    resolved_typefaces =
+        font_collection_.findTypefaces(key.style_.GetFontDescriptor());
+    for (const TypefaceRef& typeface : resolved_typefaces) {
+      CTFontRef font = static_cast<CTFontRef>(
+          default_font_manager->getPlatformFontFromTypeface(typeface));
+      if (font != nullptr) {
+        CFStringRef postscript_name = CTFontCopyPostScriptName(font);
+        if (postscript_name != nullptr) {
+          ordered_typefaces.emplace_back(typeface, postscript_name);
+        }
+      }
+    }
+  }
+
+  auto u16_str = base::U32StringToU16(
+      key.text_.data(), static_cast<uint32_t>(key.text_.length()));
+  uint32_t* u16_char_map = tmp_buf_;
+  if (u16_str.length() + 1 > SELF_RENDERING_SHAPER_BUFF_SIZE) {
+    u16_char_map = new uint32_t[u16_str.length() + 1];
+  }
+  CFAttributedStringRef cfa = GenerateAttributeString(
+      u16_str.data(), static_cast<uint32_t>(u16_str.length()), u16_char_map,
+      attributes);
+  if (resolved_typefaces.size() > 1) {
+    CFMutableAttributedStringRef ordered_cfa =
+        CFAttributedStringCreateMutableCopy(kCFAllocatorDefault, 0, cfa);
+    ApplyOrderedFamilyFonts(ordered_cfa, key.style_.GetFontSize(),
+                            resolved_typefaces);
+    CFRelease(cfa);
+    cfa = ordered_cfa;
+  }
+  auto line = CTLineCreateWithAttributedString(cfa);
+  CFArrayRef array_ref = CTLineGetGlyphRuns(line);
+  auto array_count = CFArrayGetCount(array_ref);
+
+  CTShapingResult ct_result;
+  CTFontRef prev_font = nullptr;
+  for (auto k = 0; k < array_count; k++) {
+    auto run = (CTRunRef)CFArrayGetValueAtIndex(array_ref, k);
+    auto run_status = CTRunGetStatus(run);
+    bool is_rtl = run_status & kCTRunStatusRightToLeft;
+    auto glyph_count = CTRunGetGlyphCount(run);
+
+    CFRange range = CTRunGetStringRange(run);
+    auto char32_start = u16_char_map[range.location];
+    auto char32_end = u16_char_map[range.location + range.length];
+    auto char_count = char32_end - char32_start;
+    CTFontRef font = (CTFontRef)CFDictionaryGetValue(
+        CTRunGetAttributes(run), (__bridge CFStringRef)NSFontAttributeName);
+    if (prev_font == nullptr || font != prev_font) {
+      TypefaceRef typeface;
+      if (!ordered_typefaces.empty() && font != nullptr) {
+        CFStringRef postscript_name = CTFontCopyPostScriptName(font);
+        if (postscript_name != nullptr) {
+          for (const auto& ordered_typeface : ordered_typefaces) {
+            if (CFEqual(postscript_name, ordered_typeface.second)) {
+              typeface = ordered_typeface.first;
+              break;
+            }
+          }
+          CFRelease(postscript_name);
+        }
+      }
+      if (typeface == nullptr) {
+        typeface = default_font_manager->createTypefaceFromPlatformFont(font);
+      }
+      ct_font_lst_.push_back(typeface);
+      prev_font = font;
+    }
+    TTASSERT(!ct_font_lst_.empty());
+
+    std::vector<CGGlyph> ct_glyphs(glyph_count);
+    std::vector<CGSize> ct_advances(glyph_count);
+    std::vector<CFIndex> ct_indices(glyph_count);
+    std::vector<CGPoint> ct_position(glyph_count);
+    CFRange glyph_range = CFRangeMake(0, glyph_count);
+    CTRunGetGlyphs(run, glyph_range, ct_glyphs.data());
+    CTRunGetAdvances(run, glyph_range, ct_advances.data());
+    CTRunGetStringIndices(run, glyph_range, ct_indices.data());
+    CTRunGetPositions(run, glyph_range, ct_position.data());
+    if (glyph_count > 1 && is_rtl) {
+      std::reverse(ct_glyphs.begin(), ct_glyphs.end());
+      std::reverse(ct_advances.begin(), ct_advances.end());
+      std::reverse(ct_indices.begin(), ct_indices.end());
+      std::reverse(ct_position.begin(), ct_position.end());
+      auto iter = ct_advances.rbegin();
+      while (iter != ct_advances.rend()) {
+        if (iter->width < 0 && iter != ct_advances.rbegin()) {
+          (iter - 1)->width += iter->width;
+        }
+        iter++;
+      }
+    }
+    for (auto k = 0; k < glyph_count; k++) {
+      ct_indices[k] = u16_char_map[ct_indices[k]];
+      if (ct_indices[k] >= 0 &&
+          static_cast<size_t>(ct_indices[k]) < key.text_.length() &&
+          IsZeroWidthJoiner(key.text_[static_cast<size_t>(ct_indices[k])])) {
+        ct_advances[k].width = 0;
+        ct_advances[k].height = 0;
+      }
+    }
+    /* Copy From hb-coretext.cc */
+    if (glyph_count > 1 && (run_status & kCTRunStatusNonMonotonic)) {
+      auto cluster = ct_indices[glyph_count - 1];
+      for (unsigned int i = static_cast<uint32_t>(glyph_count - 1); i > 0;
+           i--) {
+        cluster = std::min(cluster, ct_indices[i - 1]);
+        ct_indices[i - 1] = cluster;
+      }
+    }
+    ct_result.AppendResult(ct_font_lst_.back(), ct_glyphs.data(),
+                           ct_advances.data(), ct_indices.data(),
+                           ct_position.data(),
+                           static_cast<uint32_t>(glyph_count),
+                           static_cast<int32_t>(char_count), is_rtl);
+  }
+  result->AppendPlatformShapingResult(ct_result);
+  if (u16_char_map != tmp_buf_) {
+    delete[] u16_char_map;
+  }
+  CFRelease(attributes);
+  CFRelease(cfa);
+  CFRelease(line);
+  for (const auto& ordered_typeface : ordered_typefaces) {
+    CFRelease(ordered_typeface.second);
+  }
+}
+
+void ShaperCoreTextSelfRendering::ApplyOrderedFamilyFonts(
+    CFMutableAttributedStringRef attributed_string, float text_size,
+    const std::vector<TypefaceRef>& resolved_typefaces) const {
+  auto font_manager = font_collection_.GetDefaultFontManager();
+  if (attributed_string == nullptr || font_manager == nullptr ||
+      resolved_typefaces.size() < 2) {
+    return;
+  }
+
+  std::vector<CTFontRef> fonts;
+  fonts.reserve(resolved_typefaces.size());
+  for (const TypefaceRef& typeface : resolved_typefaces) {
+    CTFontRef platform_font = static_cast<CTFontRef>(
+        font_manager->getPlatformFontFromTypeface(typeface));
+    fonts.push_back(platform_font == nullptr
+                        ? nullptr
+                        : CTFontCreateCopyWithAttributes(
+                              platform_font, text_size, nullptr, nullptr));
+  }
+
+  CFStringRef cf_string = CFAttributedStringGetString(attributed_string);
+  NSString* string = (__bridge NSString*)cf_string;
+  for (NSUInteger index = 0; index < string.length;) {
+    NSRange cluster = [string rangeOfComposedCharacterSequenceAtIndex:index];
+    CFRange cluster_range = CFRangeMake(static_cast<CFIndex>(cluster.location),
+                                        static_cast<CFIndex>(cluster.length));
+    for (size_t font_index = 0; font_index < fonts.size(); ++font_index) {
+      CTFontRef font = fonts[font_index];
+      if (!FontCoversStringRangeExactly(font, cf_string, cluster_range)) {
+        continue;
+      }
+      // The base face is already installed on the full attributed string.
+      // Bind only a later explicit family; if every declared face misses, the
+      // existing CoreText cascade remains responsible for system fallback.
+      if (font_index > 0) {
+        CFAttributedStringSetAttribute(attributed_string, cluster_range,
+                                       kCTFontAttributeName, font);
+      }
+      break;
+    }
+    index = NSMaxRange(cluster);
+  }
+
+  for (CTFontRef font : fonts) {
+    if (font != nullptr) {
+      CFRelease(font);
+    }
+  }
+}
+
+CFAttributedStringRef ShaperCoreTextSelfRendering::GenerateAttributeString(
+    const char16_t* content, uint32_t length, uint32_t* u16char_map,
+    CFDictionaryRef attribute) const {
+  CFStringRef cf_string =
+      CFStringCreateWithBytes(kCFAllocatorDefault, (const UInt8*)content,
+                              length * 2, kCFStringEncodingUTF16LE, false);
+  TTASSERT(length == CFStringGetLength(cf_string));
+  auto attr_text =
+      CFAttributedStringCreate(kCFAllocatorDefault, cf_string, attribute);
+
+  // Given NSString internally uses utf16 encoding, in the sentence
+  // “给，也是在这条街，珍𤨩楼！”, the character *𤨩* will produce a surrogate
+  // character, causing the number of characters and the number of internal
+  // utf32 characters to be inconsistent, resulting in array out-of-bounds read
+  // and write. Here, we first calculate the mapping from utf16 to utf32.
+  uint32_t u32_id = 0;
+  uint32_t u16_id = 0;
+  while (u16_id < length) {
+    auto ch = content[u16_id];
+    u16char_map[u16_id++] = u32_id;
+    if (!ttoffice::base::IsLeadSurrogate(ch)) {
+      u32_id++;
+    }
+  }
+  u16char_map[u16_id] = u32_id;
+  CFRelease(cf_string);
+  return attr_text;
+}
+CFDictionaryRef ShaperCoreTextSelfRendering::GenerateAttributes(
+    const ShapeKey& key) const {
+  CFMutableDictionaryRef attributes = CFDictionaryCreateMutable(
+      kCFAllocatorDefault, 5, &kCFTypeDictionaryKeyCallBacks,
+      &kCFTypeDictionaryValueCallBacks);
+  auto style = key.style_;
+  auto text_size = style.GetFontSize();
+  auto& fd = style.GetFontDescriptor();
+  CTFontRef safe_font =
+      GetOrCreateSafeFont(fd, text_size, style.FakeBold(), style.FakeItalic());
+  if (safe_font != nullptr) {
+    CFDictionaryAddValue(attributes, kCTFontAttributeName, safe_font);
+    CFRelease(safe_font);
+  }
+  return attributes;
+}
+}  // namespace tttext
+}  // namespace ttoffice
+#undef USE_UIKIT
+#undef USE_APPKIT

--- a/src/textlayout/tt_shaper.cc
+++ b/src/textlayout/tt_shaper.cc
@@ -12,6 +12,7 @@
 #endif
 #if defined(ENABLE_CTSHAPER) || defined(ENABLE_CTSHAPER_SKITY)
 #include "src/ports/shaper/coretext/shaper_core_text.h"
+#include "src/ports/shaper/coretext/shaper_core_text_self_rendering.h"
 #endif
 #if defined(ENABLE_OHOS)
 #include "src/ports/shaper/ark_graphics/shaper_ark_graphics.h"
@@ -53,7 +54,10 @@ std::unique_ptr<TTShaper> TTShaper::CreateShaper(
       break;
 #endif
 #ifdef ENABLE_CTSHAPER
-      return std::make_unique<ShaperCoreText>(*font_collection);
+      // Ordered CoreText family matching is intentionally isolated to the
+      // self-rendering path. Keep kSystem on the legacy shaper so TextService
+      // and other system-rendered callers retain their existing behavior.
+      return std::make_unique<ShaperCoreTextSelfRendering>(*font_collection);
       break;
 #endif
       break;

--- a/src/textlayout/tt_shaper.h
+++ b/src/textlayout/tt_shaper.h
@@ -62,7 +62,7 @@ class ShapeStyle {
   friend std::hash<ShapeStyle>;
 
  public:
-  ShapeStyle() = default;
+  ShapeStyle() : hash_(UpdateHash()) {}
 
   ShapeStyle(const FontDescriptor& font_descriptor, float font_size,
              bool fake_bold, bool fake_italic)
@@ -84,23 +84,28 @@ class ShapeStyle {
 
  private:
   std::size_t UpdateHash() const {
-    std::size_t hash = 0;
+    std::size_t seed = 0;
+    const auto hash_combine = [&seed](size_t value) {
+      seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    };
     for (const auto& font_family : font_descriptor_.font_family_list_) {
-      hash ^= std::hash<std::string>()(font_family);
+      hash_combine(std::hash<std::string>()(font_family));
     }
-    hash ^= std::hash<uint64_t>()(font_descriptor_.platform_font_);
-    hash ^= std::hash<int32_t>()(font_descriptor_.font_style_.Value());
-    hash ^= std::hash<float>()(font_size_);
-    hash ^= std::hash<bool>()(fake_bold_) << 0u;
-    hash ^= std::hash<bool>()(fake_italic_) << 1u;
-    return hash;
+    hash_combine(std::hash<uint64_t>()(font_descriptor_.platform_font_));
+    hash_combine(std::hash<int32_t>()(font_descriptor_.font_style_.Value()));
+    hash_combine(std::hash<float>()(font_size_));
+    hash_combine(std::hash<bool>()(fake_bold_));
+    hash_combine(std::hash<bool>()(fake_italic_));
+    return seed;
   }
 
  public:
   bool operator==(const ShapeStyle& o) const {
     TTASSERT(hash_ == UpdateHash());
     TTASSERT(o.hash_ == o.UpdateHash());
-    return hash_ == o.hash_;
+    return hash_ == o.hash_ && font_descriptor_ == o.font_descriptor_ &&
+           font_size_ == o.font_size_ && fake_bold_ == o.fake_bold_ &&
+           fake_italic_ == o.fake_italic_;
   }
   std::size_t operator()(const ShapeStyle& k) const {
     TTASSERT(hash_ == UpdateHash());
@@ -133,7 +138,7 @@ class ShapeKey {
   friend std::hash<ShapeKey>;
 
  public:
-  ShapeKey() : text_(), style_(), rtl_(false), hash_(0) {}
+  ShapeKey() : text_(), style_(), rtl_(false), hash_(UpdateHash()) {}
   ShapeKey(const char32_t* text, uint32_t length, FontDescriptor&& p_font_list,
            float font_size, bool fake_bold, bool fake_italic, bool rtl)
       : text_(text, length),
@@ -149,8 +154,13 @@ class ShapeKey {
 
  private:
   std::size_t UpdateHash() const {
-    return std::hash<std::u32string>()(text_) ^
-           std::hash<ShapeStyle>()(style_) ^ std::hash<bool>()(rtl_);
+    std::size_t seed = std::hash<std::u32string>()(text_);
+    const auto hash_combine = [&seed](size_t value) {
+      seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+    };
+    hash_combine(std::hash<ShapeStyle>()(style_));
+    hash_combine(std::hash<bool>()(rtl_));
+    return seed;
   }
 
  public:

--- a/test/run_test.cc
+++ b/test/run_test.cc
@@ -68,6 +68,13 @@ class TestableBaseRun final : public BaseRun {
   }
 };
 
+class TestableParagraphImpl final : public ParagraphImpl {
+ public:
+  void SetBidiLevelsForTest(std::vector<uint8_t> bidi_levels) {
+    bidi_level_ = std::move(bidi_levels);
+  }
+};
+
 class MultiFontShapingResultReader final
     : public tttext::PlatformShapingResultReader {
  public:
@@ -122,6 +129,21 @@ TEST(BaseRun, Constructor) {
   EXPECT_FLOAT_EQ(run.GetStartCharPos(), start_char_pos);
   EXPECT_FLOAT_EQ(run.GetEndCharPos(), end_char_pos);
   EXPECT_EQ(run.GetType(), type);
+}
+
+TEST(BaseRun, FontFamilyOrderParticipatesInShapingMerge) {
+  TestableParagraphImpl paragraph;
+  paragraph.SetBidiLevelsForTest({0, 0});
+  Style style_ab;
+  style_ab.SetFontDescriptor(
+      FontDescriptor{{"A", "B"}, FontStyle::Normal(), 0});
+  Style style_ba;
+  style_ba.SetFontDescriptor(
+      FontDescriptor{{"B", "A"}, FontStyle::Normal(), 0});
+  BaseRun run_ab(&paragraph, style_ab.GetImpl(), 0, 1, RunType::kTextRun);
+  BaseRun run_ba(&paragraph, style_ba.GetImpl(), 1, 2, RunType::kTextRun);
+
+  EXPECT_FALSE(run_ba.CanBeAppendToShaping(run_ab));
 }
 
 TEST(BaseRun, AssignmentOperator) {

--- a/test/test_utils.h
+++ b/test/test_utils.h
@@ -281,7 +281,7 @@ class TestUtils {
       std::string& text, ParagraphHorizontalAlignment align) {
     auto paragraph = std::make_unique<ParagraphImpl>();
     //    paragraph->GetParagraphStyle().SetHorizontalAlign(align);
-    Style r_pr;
+    ttoffice::tttext::Style r_pr;
     r_pr.SetTextSize(24);
     paragraph->GetParagraphStyle().SetDefaultStyle(r_pr);
     paragraph->AddTextRun(&r_pr, text.c_str());

--- a/test/tt_shaper_test.cc
+++ b/test/tt_shaper_test.cc
@@ -14,6 +14,9 @@
 #include <unordered_set>
 #include <utility>
 
+#if defined(ENABLE_CTSHAPER)
+#include "src/ports/shaper/coretext/shaper_core_text_self_rendering.h"
+#endif
 #include "mocks.h"
 #include "src/textlayout/shape_cache.h"
 #include "test_utils.h"
@@ -143,6 +146,24 @@ TEST(ShapeStyle, SetFontDescriptor) {
   EXPECT_FALSE(old_style == new_style);
 }
 
+TEST(ShapeStyle, FamilyOrderAndAllFieldsParticipateInIdentity) {
+  FontDescriptor descriptor_ab{{"A", "B"}, FontStyle::Normal(), 0};
+  FontDescriptor descriptor_ba{{"B", "A"}, FontStyle::Normal(), 0};
+
+  ShapeStyle style_ab(descriptor_ab, 10.f, false, false);
+  ShapeStyle style_ba(descriptor_ba, 10.f, false, false);
+  ShapeStyle different_size(descriptor_ab, 11.f, false, false);
+  ShapeStyle fake_bold(descriptor_ab, 10.f, true, false);
+  ShapeStyle fake_italic(descriptor_ab, 10.f, false, true);
+
+  EXPECT_FALSE(style_ab == style_ba);
+  EXPECT_NE(std::hash<ShapeStyle>()(style_ab),
+            std::hash<ShapeStyle>()(style_ba));
+  EXPECT_FALSE(style_ab == different_size);
+  EXPECT_FALSE(style_ab == fake_bold);
+  EXPECT_FALSE(style_ab == fake_italic);
+}
+
 TEST(ShapeKey, Constructor) {
   const std::u32string text = U"Hello world";
   const float font_size = 10.f;
@@ -189,6 +210,147 @@ TEST(ShapeKey, UsedAsMapKey) {
   EXPECT_EQ(shape_map[key4], 4);
   EXPECT_EQ(shape_map[key5], 5);
 }
+
+TEST(ShapeKey, FamilyOrderAlwaysParticipatesInIdentity) {
+  const std::u32string text = U"same text";
+  const ShapeStyle style_ab(FontDescriptor{{"A", "B"}, FontStyle::Normal(), 0},
+                            10.f, false, false);
+  const ShapeStyle style_ba(FontDescriptor{{"B", "A"}, FontStyle::Normal(), 0},
+                            10.f, false, false);
+
+  ShapeKey system_ab(text.c_str(), text.size(), &style_ab, false);
+  ShapeKey system_ba(text.c_str(), text.size(), &style_ba, false);
+  EXPECT_FALSE(system_ab == system_ba);
+  EXPECT_NE(std::hash<ShapeKey>()(system_ab), std::hash<ShapeKey>()(system_ba));
+}
+
+#if defined(ENABLE_CTSHAPER)
+namespace ttoffice {
+namespace tttext {
+class ShaperCoreTextSelfRenderingTestAccess {
+ public:
+  static CTFontDescriptorRef CopyFontDescriptorWithoutCascade(
+      CTFontDescriptorRef descriptor) {
+    return ShaperCoreTextSelfRendering::CopyFontDescriptorWithoutCascade(
+        descriptor);
+  }
+
+  static CFArrayRef CreateOrderedCascadeDescriptors(
+      const std::vector<CTFontDescriptorRef>& descriptors) {
+    return ShaperCoreTextSelfRendering::CreateOrderedCascadeDescriptors(
+        descriptors);
+  }
+
+  static bool FontCoversStringRangeExactly(CTFontRef font, CFStringRef string,
+                                           CFRange range) {
+    return ShaperCoreTextSelfRendering::FontCoversStringRangeExactly(
+        font, string, range);
+  }
+
+  static size_t CacheKeyHash(const FontDescriptor& descriptor) {
+    ShaperCoreTextSelfRendering::CachedSafeFontKey key{descriptor, 10.f, false,
+                                                       false};
+    return ShaperCoreTextSelfRendering::CachedSafeFontKey::Hasher()(key);
+  }
+
+  static bool CacheKeysEqual(const FontDescriptor& lhs_descriptor,
+                             const FontDescriptor& rhs_descriptor) {
+    ShaperCoreTextSelfRendering::CachedSafeFontKey lhs{lhs_descriptor, 10.f,
+                                                       false, false};
+    ShaperCoreTextSelfRendering::CachedSafeFontKey rhs{rhs_descriptor, 10.f,
+                                                       false, false};
+    return lhs == rhs;
+  }
+};
+}  // namespace tttext
+}  // namespace ttoffice
+
+TEST(ShaperCoreTextSelfRendering, CacheKeyUsesFamilyOrder) {
+  const FontDescriptor descriptor_ab{{"A", "B"}, FontStyle::Normal(), 0};
+  const FontDescriptor descriptor_ba{{"B", "A"}, FontStyle::Normal(), 0};
+
+  EXPECT_FALSE(ShaperCoreTextSelfRenderingTestAccess::CacheKeysEqual(
+      descriptor_ab, descriptor_ba));
+  EXPECT_NE(ShaperCoreTextSelfRenderingTestAccess::CacheKeyHash(descriptor_ab),
+            ShaperCoreTextSelfRenderingTestAccess::CacheKeyHash(descriptor_ba));
+}
+
+TEST(ShaperCoreTextSelfRendering,
+     OrderedCascadeStripsNestedCascadesAndPreservesOrder) {
+  CTFontDescriptorRef descriptor_a =
+      CTFontDescriptorCreateWithNameAndSize(CFSTR("Helvetica"), 0.0);
+  CTFontDescriptorRef descriptor_b =
+      CTFontDescriptorCreateWithNameAndSize(CFSTR("Courier"), 0.0);
+  const void* nested_values[] = {descriptor_b};
+  CFArrayRef nested_cascade = CFArrayCreate(kCFAllocatorDefault, nested_values,
+                                            1, &kCFTypeArrayCallBacks);
+  const void* cascade_keys[] = {kCTFontCascadeListAttribute};
+  const void* cascade_values[] = {nested_cascade};
+  CFDictionaryRef nested_attributes = CFDictionaryCreate(
+      kCFAllocatorDefault, cascade_keys, cascade_values, 1,
+      &kCFTypeDictionaryKeyCallBacks, &kCFTypeDictionaryValueCallBacks);
+  CTFontDescriptorRef descriptor_a_with_nested_cascade =
+      CTFontDescriptorCreateCopyWithAttributes(descriptor_a, nested_attributes);
+
+  CTFontDescriptorRef descriptor_without_cascade =
+      ShaperCoreTextSelfRenderingTestAccess::CopyFontDescriptorWithoutCascade(
+          descriptor_a_with_nested_cascade);
+  CFArrayRef stripped_cascade =
+      static_cast<CFArrayRef>(CTFontDescriptorCopyAttribute(
+          descriptor_without_cascade, kCTFontCascadeListAttribute));
+  ASSERT_NE(stripped_cascade, nullptr);
+  EXPECT_EQ(CFArrayGetCount(stripped_cascade), 0);
+
+  CFArrayRef ordered_cascade =
+      ShaperCoreTextSelfRenderingTestAccess::CreateOrderedCascadeDescriptors(
+          {descriptor_a_with_nested_cascade, descriptor_b});
+  ASSERT_EQ(CFArrayGetCount(ordered_cascade), 6);
+  CTFontDescriptorRef ordered_a = static_cast<CTFontDescriptorRef>(
+      const_cast<void*>(CFArrayGetValueAtIndex(ordered_cascade, 0)));
+  CTFontDescriptorRef ordered_b = static_cast<CTFontDescriptorRef>(
+      const_cast<void*>(CFArrayGetValueAtIndex(ordered_cascade, 1)));
+  CFStringRef ordered_a_name = static_cast<CFStringRef>(
+      CTFontDescriptorCopyAttribute(ordered_a, kCTFontNameAttribute));
+  CFStringRef ordered_b_name = static_cast<CFStringRef>(
+      CTFontDescriptorCopyAttribute(ordered_b, kCTFontNameAttribute));
+  ASSERT_NE(ordered_a_name, nullptr);
+  ASSERT_NE(ordered_b_name, nullptr);
+  EXPECT_TRUE(CFEqual(ordered_a_name, CFSTR("Helvetica")));
+  EXPECT_TRUE(CFEqual(ordered_b_name, CFSTR("Courier")));
+
+  CFRelease(ordered_b_name);
+  CFRelease(ordered_a_name);
+  CFRelease(ordered_cascade);
+  CFRelease(stripped_cascade);
+  CFRelease(descriptor_without_cascade);
+  CFRelease(descriptor_a_with_nested_cascade);
+  CFRelease(nested_attributes);
+  CFRelease(nested_cascade);
+  CFRelease(descriptor_b);
+  CFRelease(descriptor_a);
+}
+
+TEST(ShaperCoreTextSelfRendering, ExactCoverageRejectsCoreTextSystemFallback) {
+  CTFontRef latin_font =
+      CTFontCreateWithName(CFSTR("Helvetica"), 16.0, nullptr);
+  CTFontRef cjk_font =
+      CTFontCreateWithName(CFSTR("PingFang SC"), 16.0, nullptr);
+  ASSERT_NE(latin_font, nullptr);
+  ASSERT_NE(cjk_font, nullptr);
+
+  CFStringRef text = CFSTR("\u4E2D");
+  const CFRange range = CFRangeMake(0, CFStringGetLength(text));
+  EXPECT_FALSE(
+      ShaperCoreTextSelfRenderingTestAccess::FontCoversStringRangeExactly(
+          latin_font, text, range));
+  EXPECT_TRUE(
+      ShaperCoreTextSelfRenderingTestAccess::FontCoversStringRangeExactly(
+          cjk_font, text, range));
+
+  CFRelease(cjk_font);
+  CFRelease(latin_font);
+}
+#endif
 
 TEST(ShapeResult, Constructor) {
   const uint32_t char_count = 10;


### PR DESCRIPTION
## Summary

- Make the complete ordered `font-family` list part of `ShapeStyle`, `ShapeKey`, and shaping-run identity. Lists such as `[A, B]` and `[B, A]` can no longer merge or share a cached shape.
- Add an isolated `ShaperCoreTextSelfRendering` implementation and route only `ShaperType::kSelfRendering` to it when CoreText shaping is enabled. `ShaperType::kSystem` continues to use the unchanged legacy `ShaperCoreText` implementation.
- Build the CoreText cascade from resolved families in declaration order: the first resolved face is the base font, later faces are appended after removing their nested cascades, and the existing safe system fallbacks remain last.
- Check composed-character clusters against the resolved faces in order and bind a later face only when it covers the cluster exactly. If no declared face covers the cluster, normal CoreText system fallback remains in control.

## Motivation

CSS Fonts requires declared families to be tried in order before system fallback. The legacy CoreText shaper selected only the first resolved typeface as its base font, so a later declared family was not reliably used when an earlier family lacked a glyph. Cascade descriptors alone are also insufficient for some dynamically registered in-memory fonts on older supported CoreText versions.

The self-rendering implementation therefore combines an ordered cascade with exact cluster coverage checks. It preserves the resolved `TypefaceRef` for explicitly selected runs so callers that render returned glyphs themselves use the same face that CoreText shaped.

## Compatibility

The new CoreText selection behavior is limited to `kSelfRendering`. System-rendered callers remain on the byte-for-byte legacy CoreText shaper and its existing cache.

The ordered family list is part of shared shape identity for all callers because family order changes font-selection semantics. The self-rendering shaper has independent safe-font cache state, so it does not share CoreText font objects with the legacy implementation.

This change does not add an app or manager cache namespace and does not invalidate global `ShapeCache` entries after late font registration or same-family replacement. Targeted cache invalidation and ownership will be handled separately.

## Testing

- Built the Linux `lynxtextra` shared library.
- Added focused tests for family-order identity, shaping-run merging, ordered cascade construction, nested-cascade removal, and exact glyph coverage.
- Validated downstream Android, iOS, and Harmony custom-font integration.
- Validated iOS CoreText compilation and explicit custom families in the first, second, and third family positions.
- Re-ran downstream NanoVG and one-line shaper custom-font cases to confirm this change does not require changes to those production paths.
