### PR TITLE
[Feature] Add shaping cache invalidation

### DIFF
--- a/public/textra/text_layout.h
+++ b/public/textra/text_layout.h
@@ -49,6 +49,10 @@ class L_EXPORT TextLayout {
  public:
   static bool Preload(ShaperType type);
 
+  // Clears all cached shaping results. New lookups cannot reuse results that
+  // were being computed when this method was called.
+  static void ClearShapeCache();
+
   LayoutResult Layout(Paragraph* para, LayoutRegion* page,
                       TTTextContext& context) const {
     return LayoutEx(para, page, context);

--- a/src/textlayout/shape_cache.h
+++ b/src/textlayout/shape_cache.h
@@ -8,7 +8,9 @@
 #include <textra/font_info.h>
 
 #include <algorithm>
+#include <cstdint>
 #include <memory>
+#include <mutex>
 #include <shared_mutex>
 #include <unordered_map>
 
@@ -112,6 +114,8 @@ namespace ttoffice {
 namespace tttext {
 class ShapeCache final {
  public:
+  using Epoch = uint64_t;
+
   static ShapeCache& GetInstance() {
     static ShapeCache* instance = new ShapeCache();
     return *instance;
@@ -127,16 +131,26 @@ class ShapeCache final {
  public:
   void AddToCache(const ShapeKey& key, const ShapeResultRef& result) {
     std::unique_lock lock(mutex_);
-#ifdef USE_LRU_CACHE
-    TTASSERT(shape_cache_.get(key) == nullptr);
-    shape_cache_.put(key, result);
-#else
-    TTASSERT(shape_cache_.find(key) == shape_cache_.end());
-    shape_cache_.insert({key, result});
-#endif
+    AddToCacheLocked(key, result);
   }
-  std::shared_ptr<ShapeResult> Find(const ShapeKey& key) {
+
+  void AddToCache(const ShapeKey& key, const ShapeResultRef& result,
+                  Epoch epoch) {
+    std::unique_lock lock(mutex_);
+    // A font-manager update may clear the cache while shaping is in flight.
+    // Do not let a result made with the old font set repopulate the cache.
+    if (epoch != epoch_) {
+      return;
+    }
+    AddToCacheLocked(key, result);
+  }
+
+  std::shared_ptr<ShapeResult> Find(const ShapeKey& key,
+                                    Epoch* epoch = nullptr) {
     std::shared_lock lock(mutex_);
+    if (epoch != nullptr) {
+      *epoch = epoch_;
+    }
 #ifdef USE_LRU_CACHE
     auto iter = shape_cache_.get(key);
     return iter == nullptr ? nullptr : *iter;
@@ -146,7 +160,23 @@ class ShapeCache final {
 #endif
   }
 
+  void Clear() {
+    std::unique_lock lock(mutex_);
+    shape_cache_.clear();
+    ++epoch_;
+  }
+
  private:
+  void AddToCacheLocked(const ShapeKey& key, const ShapeResultRef& result) {
+#ifdef USE_LRU_CACHE
+    TTASSERT(shape_cache_.get(key) == nullptr);
+    shape_cache_.put(key, result);
+#else
+    TTASSERT(shape_cache_.find(key) == shape_cache_.end());
+    shape_cache_.insert({key, result});
+#endif
+  }
+
 #ifdef USE_LRU_CACHE
   android::LruCache<const ShapeKey, ShapeResultRef> shape_cache_{
       android::LruCache<const ShapeKey,
@@ -155,6 +185,7 @@ class ShapeCache final {
   std::unordered_map<const ShapeKey, ShapeResultRef> shape_cache_;
 #endif
   mutable std::shared_mutex mutex_{};
+  Epoch epoch_ = 0;
 };
 }  // namespace tttext
 }  // namespace ttoffice

--- a/src/textlayout/text_layout.cc
+++ b/src/textlayout/text_layout.cc
@@ -8,6 +8,7 @@
 #include <textra/text_layout.h>
 #include <textra/tttext_context.h>
 
+#include "src/textlayout/shape_cache.h"
 #include "src/textlayout/text_layout_impl.h"
 #include "src/textlayout/tt_shaper.h"
 
@@ -23,6 +24,8 @@ TextLayout::TextLayout(std::unique_ptr<TTShaper> shaper)
 TextLayout::~TextLayout() = default;
 
 bool TextLayout::Preload(ShaperType type) { return TTShaper::Preload(type); }
+
+void TextLayout::ClearShapeCache() { ShapeCache::GetInstance().Clear(); }
 
 LayoutResult TextLayout::LayoutEx(Paragraph* para, LayoutRegion* page,
                                   TTTextContext& context) const {

--- a/src/textlayout/tt_shaper.cc
+++ b/src/textlayout/tt_shaper.cc
@@ -103,8 +103,10 @@ ShapeResultRef TTShaper::ShapeText(const char32_t* text, uint32_t length,
   const ShapeKey key(text, length, shape_style, rtl);
   const auto disable_shape_cache =
       context_ != nullptr && context_->GetImpl().IsShapeCacheDisabled();
-  auto result =
-      disable_shape_cache ? nullptr : ShapeCache::GetInstance().Find(key);
+  ShapeCache::Epoch cache_epoch = 0;
+  auto result = disable_shape_cache
+                    ? nullptr
+                    : ShapeCache::GetInstance().Find(key, &cache_epoch);
   if (result == nullptr) {
     result = std::make_shared<ShapeResult>(length, rtl);
     OnShapeText(key, result.get());
@@ -117,7 +119,7 @@ ShapeResultRef TTShaper::ShapeText(const char32_t* text, uint32_t length,
       }
     }
     if (!disable_shape_cache) {
-      ShapeCache::GetInstance().AddToCache(key, result);
+      ShapeCache::GetInstance().AddToCache(key, result, cache_epoch);
     }
   }
   TTASSERT(result != nullptr);

--- a/test/shape_cache_test.cc
+++ b/test/shape_cache_test.cc
@@ -91,6 +91,32 @@ TEST(ShapeCache, Singleton) {
   EXPECT_EQ(&cache1, &cache2);
 }
 
+TEST(ShapeCache, ClearRemovesAllEntries) {
+  ShapeKey key(U"clear", 5, FontDescriptor(), 10.f, false, false, false);
+  auto result = std::make_shared<ShapeResult>(1, false);
+  ShapeCache& cache = ShapeCache::GetInstance();
+  cache.Clear();
+  cache.AddToCache(key, result);
+
+  EXPECT_EQ(cache.Find(key), result);
+  cache.Clear();
+  EXPECT_EQ(cache.Find(key), nullptr);
+}
+
+TEST(ShapeCache, ClearRejectsAnInFlightResultFromThePreviousEpoch) {
+  ShapeKey key(U"stale", 5, FontDescriptor(), 10.f, false, false, false);
+  auto result = std::make_shared<ShapeResult>(1, false);
+  ShapeCache& cache = ShapeCache::GetInstance();
+  cache.Clear();
+
+  ShapeCache::Epoch epoch = 0;
+  EXPECT_EQ(cache.Find(key, &epoch), nullptr);
+  cache.Clear();
+  cache.AddToCache(key, result, epoch);
+
+  EXPECT_EQ(cache.Find(key), nullptr);
+}
+
 TEST(ShapeResultPiece, GlyphCountIncludesLigatureGlyphs) {
   auto result = std::make_shared<ShapeResult>(3, false);
   LigatureShapeResultReader reader;


### PR DESCRIPTION
## Summary

- Add `TextLayout::ClearShapeCache()` as a public API for clearing all cached shaping results.
- Track a cache epoch so shaping work that started before a clear cannot repopulate the cache with stale results.
- Add focused tests for clearing existing entries and rejecting in-flight results from an earlier epoch.

## Motivation

Font registrations can change the available typefaces after a shaping result has already been cached. Callers need an explicit way to invalidate those results so the next layout observes the updated font set.

Clearing the map alone is insufficient because shaping happens outside the cache lock. A shape operation that started before the clear could otherwise finish afterward and insert a result produced with the old font state. Capturing and validating an epoch at lookup and insertion prevents that stale write-back without holding the cache lock while shaping.

## Scope

This PR only provides the Textra cache invalidation capability. Integration code that invokes it when a font is registered is maintained separately by downstream callers.

## Testing

- Built the Linux `lynxtextra` shared library.
- Passed `cpplint`.
- Passed `coding-style`.
- Added macOS unit tests for cache clearing and in-flight stale-result rejection; these run in GitHub Actions because the repository only defines `TextLayoutLiteTest` on Darwin.
