### PR TITLE
[BugFix] fix bidi-aware ellipsis truncation

### DIFF
--- a/src/textlayout/text_line_impl.cc
+++ b/src/textlayout/text_line_impl.cc
@@ -209,9 +209,9 @@ void TextLineImpl::InsertDrawerPiece(
 }
 bool TextLineImpl::StripContentByWidth(float space) {
   auto& range = range_lst_.back();
-  auto range_width = range->x_max_;
+  auto range_width = range->GetRangeWidth();
   if (range_width < space) return false;
-  float total_width = range->x_min_;
+  float total_width = 0;
   for (auto& drawer : drawer_list_) {
     if (drawer->GetParent() == range.get()) {
       total_width += drawer->GetWidthWithIndent();
@@ -221,32 +221,60 @@ bool TextLineImpl::StripContentByWidth(float space) {
   if (space <= 0 || drawer_list_.empty()) {
     return true;
   }
-  int32_t index = static_cast<int32_t>(drawer_list_.size()) - 1;
-  while (space > 0 && index >= 0) {
+  const bool strip_from_start =
+      paragraph_->GetResolvedWriteDirection() == WriteDirection::kRTL;
+  size_t first_piece = 0;
+  size_t last_piece = drawer_list_.size();
+  uint32_t stripped_char_count = 0;
+  while (space > 0 && first_piece < last_piece) {
+    const size_t index = strip_from_start ? first_piece : last_piece - 1;
     auto& piece = drawer_list_[index];
     if (space > piece->GetWidthWithIndent() || !piece->GetRun()->IsTextRun()) {
-      index--;
       space -= piece->GetWidthWithIndent();
-      drawer_list_.pop_back();
+      if (!piece->GetRun()->IsGhostRun()) {
+        stripped_char_count += piece->GetCharCount();
+      }
+      if (strip_from_start) {
+        ++first_piece;
+      } else {
+        --last_piece;
+      }
     } else {
-      index--;
+      const auto piece_end_pos = piece->GetEndCharPosInParagraph();
       auto end_pos =
           piece->FindCharPosInParagraphByX(piece->GetWidthWithIndent() - space);
+      stripped_char_count += piece_end_pos - end_pos;
       if (end_pos == piece->GetStartCharPosInParagraph()) {
-        drawer_list_.pop_back();
+        if (strip_from_start) {
+          ++first_piece;
+        } else {
+          --last_piece;
+        }
       } else {
         auto* piece_run = piece->GetRun();
         auto new_piece = std::make_unique<RunRange>(
             piece_run, piece->GetParent(),
             piece->GetStartCharPosInParagraph() - piece_run->GetStartCharPos(),
             end_pos - piece_run->GetStartCharPos());
-        drawer_list_.pop_back();
-        drawer_list_.emplace_back(std::move(new_piece));
+        drawer_list_[index] = std::move(new_piece);
       }
       space = 0;
     }
   }
-  return FloatsLargerOrEqual(0, space);
+  if (strip_from_start) {
+    drawer_list_.erase(drawer_list_.begin(),
+                       drawer_list_.begin() + first_piece);
+  } else {
+    drawer_list_.erase(drawer_list_.begin() + last_piece, drawer_list_.end());
+  }
+  const bool strip_succeeded = FloatsLargerOrEqual(0, space);
+  if (strip_succeeded) {
+    const auto original_end_pos = GetEndCharPos();
+    TTASSERT(stripped_char_count <= original_end_pos - GetStartCharPos());
+    line_end_pos_ = paragraph_->CharPosToLayoutPosition(original_end_pos -
+                                                        stripped_char_count);
+  }
+  return strip_succeeded;
 }
 
 void TextLineImpl::AppendGhostRun(std::unique_ptr<BaseRun> ghost_run) {

--- a/test/text_layout_test.cc
+++ b/test/text_layout_test.cc
@@ -715,6 +715,7 @@ TEST_F(TextLayoutTest, ParagraphStyle_WriteDirection) {
     line->GetCharBoundingRect(text_run_rect, line->GetStartCharPos());
     // Expected output: "The quick..."
     EXPECT_FLOAT_EQ(text_run_rect[0], 0.f);
+    EXPECT_EQ(line->GetEndCharPos(), 9u);
   }
   {
     // Test RTL direction
@@ -725,7 +726,64 @@ TEST_F(TextLayoutTest, ParagraphStyle_WriteDirection) {
     line->GetCharBoundingRect(text_run_rect, line->GetStartCharPos());
     // Expected output: "...The quick"
     EXPECT_FLOAT_EQ(text_run_rect[0], strlen(ellipsis) * text_size);
+    EXPECT_EQ(line->GetEndCharPos(), 9u);
   }
+}
+
+TEST_F(TextLayoutTest, ParagraphStyle_EllipsisMixedBidiStripsFromRtlStart) {
+  auto para = std::make_unique<ParagraphImpl>();
+  Style style;
+  style.SetTextSize(1.f);
+  ParagraphStyle para_style;
+  para_style.SetDefaultStyle(style);
+  para_style.SetWriteDirection(WriteDirection::kRTL);
+  para_style.SetMaxLines(1);
+  para_style.SetEllipsis(".");
+  para->SetParagraphStyle(&para_style);
+  para->AddTextRun(&style, "abcdef");
+
+  TextLayout layout(TestUtils::CreateFixedBidiTestShaper({5, 4, 2, 3, 1, 0},
+                                                         {1, 1, 2, 2, 1, 1}));
+  TTTextContext context;
+  auto region = std::make_unique<LayoutRegion>(4.f, 3.f);
+  layout.Layout(para.get(), region.get(), context);
+
+  ASSERT_EQ(region->GetLineCount(), 1u);
+  auto* line = region->GetLine(0);
+  float retained_char_rect[4];
+  float stripped_char_rect[4];
+  line->GetCharBoundingRect(retained_char_rect, 1);
+  line->GetCharBoundingRect(stripped_char_rect, 3);
+
+  EXPECT_FLOAT_EQ(retained_char_rect[2], 1.f);
+  EXPECT_FLOAT_EQ(stripped_char_rect[2], 0.f);
+  EXPECT_EQ(line->GetEndCharPos(), 3u);
+}
+
+TEST_F(TextLayoutTest, ParagraphStyle_EllipsisWiderThanIndentedRange) {
+  auto para = std::make_unique<ParagraphImpl>();
+  Style style;
+  style.SetTextSize(1.f);
+  ParagraphStyle para_style;
+  para_style.SetDefaultStyle(style);
+  para_style.SetFirstLineIndentInPx(3.f);
+  para_style.SetMaxLines(1);
+  para_style.SetEllipsis("..");
+  para->SetParagraphStyle(&para_style);
+  para->AddTextRun(&style, "ab");
+
+  TextLayout layout(GetFixedSizeMockShaper());
+  TTTextContext context;
+  auto region = std::make_unique<LayoutRegion>(4.f, 3.f);
+  layout.Layout(para.get(), region.get(), context);
+
+  ASSERT_EQ(region->GetLineCount(), 1u);
+  auto* line = region->GetLine(0);
+  float text_rect[4];
+  line->GetCharBoundingRect(text_rect, 0);
+  EXPECT_FLOAT_EQ(text_rect[0], 3.f);
+  EXPECT_FLOAT_EQ(text_rect[2], 1.f);
+  EXPECT_EQ(line->GetEndCharPos(), 1u);
 }
 
 TEST_F(TextLayoutTest, ParagraphStyle_WriteDirectionUpdatesAfterLayout) {

--- a/test/text_test.cc
+++ b/test/text_test.cc
@@ -316,7 +316,7 @@ TEST(TextTest, EllipsisWithIndentTest) {
   constexpr float width = 101;
   auto region = TestUtils::SimpleLayoutParagraphByWidth(para.get(), width);
   EXPECT_EQ(region->GetLine(0)->GetCharCount(), 10u);
-  EXPECT_EQ(region->GetLine(1)->GetCharCount(), 8u);
+  EXPECT_EQ(region->GetLine(1)->GetCharCount(), 5u);
   auto* line = region->GetLine(1);
   float rect[4];
   line->GetBoundingRectByCharRange(rect, line->GetStartCharPos(),


### PR DESCRIPTION
- strip from the correct edge for RTL and LTR paragraphs
- use the available range width and update the line end position
- add mixed-bidi and indented ellipsis regression tests