### PR TITLE
[Feature] Support configurable shaping cache scopes

### DIFF
--- a/LynxTextra.podspec
+++ b/LynxTextra.podspec
@@ -135,6 +135,7 @@ Pod::Spec.new do |s|
                                 "src/textlayout/run/ghost_run.h",
                                 "src/textlayout/run/layout_metrics.h",
                                 "src/textlayout/run/object_run.h",
+                                "src/textlayout/shape_cache.cc",
                                 "src/textlayout/shape_cache.h",
                                 "src/textlayout/style/paragraph_style_impl.cc",
                                 "src/textlayout/style/paragraph_style_impl.h",

--- a/public/textra/layout_definition.h
+++ b/public/textra/layout_definition.h
@@ -192,12 +192,22 @@ enum LineBreakStrategy : uint8_t {
   kAvoidBreakAroundPunctuation = 1,
   kLineBreakStrategyDefault = 0xff,
 };
+enum class ShapeCacheMode : uint8_t {
+  // Reuse shaping results across TextLayout instances.
+  kGlobal = 0,
+  // Reuse shaping results only within one TextLayout instance.
+  kInstance = 1,
+  // Always shape text without reading or writing cached results.
+  kDisabled = 2,
+};
 enum FeatureOption : uint8_t {
   kLastLineCanOverflow,
   kSkipSpaceBeforeFirstLine,
   kTrimLineTailSpace,
   kHarmonyShaperForceUseLowAPI,
   kSystemFontAdjust,
+  // Deprecated: use TTTextContext::SetShapeCacheMode instead. This option
+  // only maps true to kDisabled and false to kGlobal.
   kDisableShapeCache,
 };
 enum class DominantBaseline : uint8_t {

--- a/public/textra/text_layout.h
+++ b/public/textra/text_layout.h
@@ -49,9 +49,15 @@ class L_EXPORT TextLayout {
  public:
   static bool Preload(ShaperType type);
 
-  // Clears all cached shaping results. New lookups cannot reuse results that
-  // were being computed when this method was called.
+  // Clears the global shaping cache. Kept for backward compatibility.
   static void ClearShapeCache();
+
+  // Clears the global shaping cache. New lookups cannot reuse results that
+  // were being computed when this method was called.
+  static void ClearGlobalShapeCache();
+
+  // Clears shaping results cached by this TextLayout instance.
+  void ClearInstanceShapeCache();
 
   LayoutResult Layout(Paragraph* para, LayoutRegion* page,
                       TTTextContext& context) const {

--- a/public/textra/tttext_context.h
+++ b/public/textra/tttext_context.h
@@ -65,6 +65,14 @@ class L_EXPORT TTTextContext {
   bool IsEnableSystemFontAdjust() const;
   void SetEnableSystemFontAdjust(bool enable_system_font_adjust);
 
+  /**
+   * @brief Selects the shaping cache used by layout operations.
+   *
+   * The default mode is ShapeCacheMode::kGlobal.
+   */
+  ShapeCacheMode GetShapeCacheMode() const;
+  void SetShapeCacheMode(ShapeCacheMode mode);
+
   void EnableFeature(FeatureOption feature_option, bool value);
 
   // Layout state getters/setters

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -244,6 +244,7 @@ source_set("textlayout") {
     "$prj_root/src/textlayout/run/ghost_run.h",
     "$prj_root/src/textlayout/run/layout_metrics.h",
     "$prj_root/src/textlayout/run/object_run.h",
+    "$prj_root/src/textlayout/shape_cache.cc",
     "$prj_root/src/textlayout/shape_cache.h",
     "$prj_root/src/textlayout/style/paragraph_style_impl.cc",
     "$prj_root/src/textlayout/style/paragraph_style_impl.h",

--- a/src/textlayout/shape_cache.cc
+++ b/src/textlayout/shape_cache.cc
@@ -1,0 +1,112 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include "src/textlayout/shape_cache.h"
+
+#include <mutex>
+#include <shared_mutex>
+#include <unordered_map>
+
+#ifdef USE_LRU_CACHE
+#include "src/textlayout/utils/lru_cache.h"
+
+namespace android {
+template <>
+inline uint32_t hash_type<tttext::ShapeKey>(const tttext::ShapeKey& key) {
+  return hash_type(static_cast<uint64_t>(key.hash_));
+}
+}  // namespace android
+#endif
+
+namespace ttoffice {
+namespace tttext {
+
+class ShapeCache::Impl {
+ public:
+  void AddToCache(const ShapeKey& key, const ShapeResultRef& result) {
+    std::unique_lock lock(mutex_);
+    AddToCacheLocked(key, result);
+  }
+
+  void AddToCache(const ShapeKey& key, const ShapeResultRef& result,
+                  Epoch epoch) {
+    std::unique_lock lock(mutex_);
+    if (epoch != epoch_) {
+      return;
+    }
+    AddToCacheLocked(key, result);
+  }
+
+  ShapeResultRef Find(const ShapeKey& key, Epoch* epoch) {
+#ifdef USE_LRU_CACHE
+    std::unique_lock lock(mutex_);
+#else
+    std::shared_lock lock(mutex_);
+#endif
+    if (epoch != nullptr) {
+      *epoch = epoch_;
+    }
+#ifdef USE_LRU_CACHE
+    auto* result = shape_cache_.get(key);
+    return result == nullptr ? nullptr : *result;
+#else
+    auto iter = shape_cache_.find(key);
+    return iter == shape_cache_.end() ? nullptr : iter->second;
+#endif
+  }
+
+  void Clear() {
+    std::unique_lock lock(mutex_);
+    shape_cache_.clear();
+    ++epoch_;
+  }
+
+ private:
+  void AddToCacheLocked(const ShapeKey& key, const ShapeResultRef& result) {
+#ifdef USE_LRU_CACHE
+    if (shape_cache_.get(key) == nullptr) {
+      shape_cache_.put(key, result);
+    }
+#else
+    shape_cache_.insert({key, result});
+#endif
+  }
+
+#ifdef USE_LRU_CACHE
+  android::LruCache<const ShapeKey, ShapeResultRef> shape_cache_{
+      android::LruCache<const ShapeKey,
+                        ShapeResultRef>::Capacity::kDefaultCapacity};
+#else
+  std::unordered_map<const ShapeKey, ShapeResultRef> shape_cache_;
+#endif
+  mutable std::shared_mutex mutex_;
+  Epoch epoch_ = 0;
+};
+
+ShapeCache::ShapeCache() : impl_(std::make_unique<Impl>()) {}
+
+ShapeCache::~ShapeCache() = default;
+
+ShapeCache& ShapeCache::GetInstance() {
+  static ShapeCache* instance = new ShapeCache();
+  return *instance;
+}
+
+void ShapeCache::AddToCache(const ShapeKey& key, const ShapeResultRef& result) {
+  impl_->AddToCache(key, result);
+}
+
+void ShapeCache::AddToCache(const ShapeKey& key, const ShapeResultRef& result,
+                            Epoch epoch) {
+  impl_->AddToCache(key, result, epoch);
+}
+
+ShapeResultRef ShapeCache::Find(const ShapeKey& key, Epoch* epoch) {
+  return impl_->Find(key, epoch);
+}
+
+void ShapeCache::Clear() { impl_->Clear(); }
+
+}  // namespace tttext
+}  // namespace ttoffice

--- a/src/textlayout/shape_cache.h
+++ b/src/textlayout/shape_cache.h
@@ -10,9 +10,6 @@
 #include <algorithm>
 #include <cstdint>
 #include <memory>
-#include <mutex>
-#include <shared_mutex>
-#include <unordered_map>
 
 #include "src/textlayout/tt_shaper.h"
 namespace ttoffice {
@@ -83,16 +80,6 @@ class ShapeResultPiece {
 }  // namespace tttext
 }  // namespace ttoffice
 using ShapeResultRef = std::shared_ptr<tttext::ShapeResult>;
-#ifdef USE_LRU_CACHE
-#include "src/textlayout/utils/lru_cache.h"
-namespace android {
-template <>
-inline uint32_t hash_type<tttext::ShapeKey>(const tttext::ShapeKey& key) {
-  return hash_type(static_cast<uint64_t>(key.hash_));
-}
-}  // namespace android
-
-#endif
 
 namespace std {
 template <>
@@ -116,76 +103,22 @@ class ShapeCache final {
  public:
   using Epoch = uint64_t;
 
-  static ShapeCache& GetInstance() {
-    static ShapeCache* instance = new ShapeCache();
-    return *instance;
-  }
+  ShapeCache();
+  ~ShapeCache();
 
   ShapeCache(const ShapeCache& other) = delete;
   void operator=(const ShapeCache& other) = delete;
 
- private:
-  ShapeCache() = default;
-  ~ShapeCache() = default;
-
- public:
-  void AddToCache(const ShapeKey& key, const ShapeResultRef& result) {
-    std::unique_lock lock(mutex_);
-    AddToCacheLocked(key, result);
-  }
-
+  static ShapeCache& GetInstance();
+  void AddToCache(const ShapeKey& key, const ShapeResultRef& result);
   void AddToCache(const ShapeKey& key, const ShapeResultRef& result,
-                  Epoch epoch) {
-    std::unique_lock lock(mutex_);
-    // A font-manager update may clear the cache while shaping is in flight.
-    // Do not let a result made with the old font set repopulate the cache.
-    if (epoch != epoch_) {
-      return;
-    }
-    AddToCacheLocked(key, result);
-  }
-
-  std::shared_ptr<ShapeResult> Find(const ShapeKey& key,
-                                    Epoch* epoch = nullptr) {
-    std::shared_lock lock(mutex_);
-    if (epoch != nullptr) {
-      *epoch = epoch_;
-    }
-#ifdef USE_LRU_CACHE
-    auto iter = shape_cache_.get(key);
-    return iter == nullptr ? nullptr : *iter;
-#else
-    auto iter = shape_cache_.find(key);
-    return iter == shape_cache_.end() ? nullptr : iter->second;
-#endif
-  }
-
-  void Clear() {
-    std::unique_lock lock(mutex_);
-    shape_cache_.clear();
-    ++epoch_;
-  }
+                  Epoch epoch);
+  ShapeResultRef Find(const ShapeKey& key, Epoch* epoch = nullptr);
+  void Clear();
 
  private:
-  void AddToCacheLocked(const ShapeKey& key, const ShapeResultRef& result) {
-#ifdef USE_LRU_CACHE
-    TTASSERT(shape_cache_.get(key) == nullptr);
-    shape_cache_.put(key, result);
-#else
-    TTASSERT(shape_cache_.find(key) == shape_cache_.end());
-    shape_cache_.insert({key, result});
-#endif
-  }
-
-#ifdef USE_LRU_CACHE
-  android::LruCache<const ShapeKey, ShapeResultRef> shape_cache_{
-      android::LruCache<const ShapeKey,
-                        ShapeResultRef>::Capacity::kDefaultCapacity};
-#else
-  std::unordered_map<const ShapeKey, ShapeResultRef> shape_cache_;
-#endif
-  mutable std::shared_mutex mutex_{};
-  Epoch epoch_ = 0;
+  class Impl;
+  std::unique_ptr<Impl> impl_;
 };
 }  // namespace tttext
 }  // namespace ttoffice

--- a/src/textlayout/text_layout.cc
+++ b/src/textlayout/text_layout.cc
@@ -25,7 +25,13 @@ TextLayout::~TextLayout() = default;
 
 bool TextLayout::Preload(ShaperType type) { return TTShaper::Preload(type); }
 
-void TextLayout::ClearShapeCache() { ShapeCache::GetInstance().Clear(); }
+void TextLayout::ClearShapeCache() { ClearGlobalShapeCache(); }
+
+void TextLayout::ClearGlobalShapeCache() { ShapeCache::GetInstance().Clear(); }
+
+void TextLayout::ClearInstanceShapeCache() {
+  shaper_->ClearInstanceShapeCache();
+}
 
 LayoutResult TextLayout::LayoutEx(Paragraph* para, LayoutRegion* page,
                                   TTTextContext& context) const {

--- a/src/textlayout/tt_shaper.cc
+++ b/src/textlayout/tt_shaper.cc
@@ -26,7 +26,6 @@
 #include "src/textlayout/run/base_run.h"
 #include "src/textlayout/shape_cache.h"
 #include "src/textlayout/style/style_manager.h"
-#include "src/textlayout/tttext_context_impl.h"
 #include "src/textlayout/utils/log_util.h"
 namespace ttoffice {
 namespace tttext {
@@ -87,6 +86,11 @@ bool TTShaper::Preload(ShaperType type) {
 TTShaper::TTShaper(FontmgrCollection font_collection) noexcept
     : font_collection_(font_collection), context_(nullptr) {}
 TTShaper::~TTShaper() = default;
+void TTShaper::ClearInstanceShapeCache() {
+  if (shape_cache_ != nullptr) {
+    shape_cache_->Clear();
+  }
+}
 void TTShaper::ProcessBidirection(const char32_t* text, uint32_t length,
                                   WriteDirection write_direction,
                                   uint32_t* visual_map, uint32_t* logical_map,
@@ -101,12 +105,24 @@ ShapeResultRef TTShaper::ShapeText(const char32_t* text, uint32_t length,
                                    const ShapeStyle* shape_style,
                                    bool rtl) const {
   const ShapeKey key(text, length, shape_style, rtl);
-  const auto disable_shape_cache =
-      context_ != nullptr && context_->GetImpl().IsShapeCacheDisabled();
+  const auto cache_mode = context_ == nullptr ? ShapeCacheMode::kGlobal
+                                              : context_->GetShapeCacheMode();
+  ShapeCache* cache = nullptr;
+  switch (cache_mode) {
+    case ShapeCacheMode::kGlobal:
+      cache = &ShapeCache::GetInstance();
+      break;
+    case ShapeCacheMode::kInstance:
+      if (shape_cache_ == nullptr) {
+        shape_cache_ = std::make_unique<ShapeCache>();
+      }
+      cache = shape_cache_.get();
+      break;
+    case ShapeCacheMode::kDisabled:
+      break;
+  }
   ShapeCache::Epoch cache_epoch = 0;
-  auto result = disable_shape_cache
-                    ? nullptr
-                    : ShapeCache::GetInstance().Find(key, &cache_epoch);
+  auto result = cache == nullptr ? nullptr : cache->Find(key, &cache_epoch);
   if (result == nullptr) {
     result = std::make_shared<ShapeResult>(length, rtl);
     OnShapeText(key, result.get());
@@ -118,8 +134,8 @@ ShapeResultRef TTShaper::ShapeText(const char32_t* text, uint32_t length,
         result->advances_[result->CharToGlyph(k)][1] = 0;
       }
     }
-    if (!disable_shape_cache) {
-      ShapeCache::GetInstance().AddToCache(key, result, cache_epoch);
+    if (cache != nullptr) {
+      cache->AddToCache(key, result, cache_epoch);
     }
   }
   TTASSERT(result != nullptr);

--- a/src/textlayout/tt_shaper.h
+++ b/src/textlayout/tt_shaper.h
@@ -49,6 +49,7 @@ class TTShaper {
                                   uint32_t* visual_map, uint32_t* logical_map,
                                   uint8_t* dir_vec);
   virtual void OnShapeText(const ShapeKey& key, ShapeResult* result) const = 0;
+  void ClearInstanceShapeCache();
   std::shared_ptr<ShapeResult> ShapeText(const char32_t* text, uint32_t length,
                                          const ShapeStyle* shape_style,
                                          bool rtl) const;
@@ -56,6 +57,7 @@ class TTShaper {
  protected:
   FontmgrCollection font_collection_;
   TTTextContext* context_;
+  mutable std::unique_ptr<ShapeCache> shape_cache_;
 };
 
 class ShapeStyle {

--- a/src/textlayout/tttext_context_impl.cc
+++ b/src/textlayout/tttext_context_impl.cc
@@ -20,7 +20,7 @@ TTTextContextImpl::TTTextContextImpl()
       trim_line_tail_space_(true),
       harmony_shaper_force_low_api_(false),
       enable_system_font_adjust_(false),
-      disable_shape_cache_(false),
+      shape_cache_mode_(ShapeCacheMode::kGlobal),
       layout_bottom_(0) {}
 
 TTTextContext::TTTextContext() : impl_(std::make_unique<TTTextContextImpl>()) {}
@@ -60,6 +60,14 @@ void TTTextContext::SetEnableSystemFontAdjust(bool enable_system_font_adjust) {
   impl_->enable_system_font_adjust_ = enable_system_font_adjust;
 }
 
+ShapeCacheMode TTTextContext::GetShapeCacheMode() const {
+  return impl_->shape_cache_mode_;
+}
+
+void TTTextContext::SetShapeCacheMode(ShapeCacheMode mode) {
+  impl_->shape_cache_mode_ = mode;
+}
+
 void TTTextContext::EnableFeature(FeatureOption feature_option, bool value) {
   switch (feature_option) {
     case kLastLineCanOverflow:
@@ -78,7 +86,8 @@ void TTTextContext::EnableFeature(FeatureOption feature_option, bool value) {
       impl_->enable_system_font_adjust_ = value;
       break;
     case kDisableShapeCache:
-      impl_->disable_shape_cache_ = value;
+      impl_->shape_cache_mode_ =
+          value ? ShapeCacheMode::kDisabled : ShapeCacheMode::kGlobal;
       break;
     default:
       break;

--- a/src/textlayout/tttext_context_impl.h
+++ b/src/textlayout/tttext_context_impl.h
@@ -4,6 +4,8 @@
 
 #ifndef SRC_TEXTLAYOUT_TTTEXT_CONTEXT_IMPL_H_
 #define SRC_TEXTLAYOUT_TTTEXT_CONTEXT_IMPL_H_
+#include <textra/layout_definition.h>
+
 #include <memory>
 
 #include "src/textlayout/layout_position.h"
@@ -21,7 +23,6 @@ class TTTextContextImpl {
     return harmony_shaper_force_low_api_;
   }
   bool IsEnableSystemFontAdjust() const { return enable_system_font_adjust_; }
-  bool IsShapeCacheDisabled() const { return disable_shape_cache_; }
   bool IsTrimLineTailSpace() const { return trim_line_tail_space_; }
 
  private:
@@ -32,7 +33,7 @@ class TTTextContextImpl {
   bool trim_line_tail_space_;
   bool harmony_shaper_force_low_api_;
   bool enable_system_font_adjust_;
-  bool disable_shape_cache_;
+  ShapeCacheMode shape_cache_mode_;
   float layout_bottom_;
 };
 }  // namespace tttext

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -60,6 +60,9 @@ executable("TextLayoutLiteTest") {
     "FONT_ROOT=\"$project_root/fonts/\"",
     "GOLDEN_IMAGES_DIR=\"$golden_images_dir/\"",
   ]
+  if (use_lru_cache) {
+    defines += [ "USE_LRU_CACHE=1" ]
+  }
 
   cflags_cc = [
     "-Wno-unused-function",

--- a/test/shape_cache_test.cc
+++ b/test/shape_cache_test.cc
@@ -7,6 +7,9 @@
 #include <gtest/gtest.h>
 #include <textra/font_info.h>
 
+#include <thread>
+#include <vector>
+
 #include "src/textlayout/tt_shaper.h"
 #include "test_utils.h"
 
@@ -41,6 +44,9 @@ class LigatureShapeResultReader final : public PlatformShapingResultReader {
 }  // namespace
 
 TEST(ShapeCache, AddToCacheAndFind) {
+  ShapeCache& cache = ShapeCache::GetInstance();
+  cache.Clear();
+
   FontDescriptor font1;
   FontDescriptor font2;
   font2.font_style_ = FontStyle::Bold();
@@ -67,7 +73,6 @@ TEST(ShapeCache, AddToCacheAndFind) {
   const ShapeResultRef result6 = create_fake_shape_result({6});
   const ShapeResultRef result7 = create_fake_shape_result({7});
 
-  ShapeCache& cache = ShapeCache::GetInstance();
   cache.AddToCache(key1, result1);
   cache.AddToCache(key2, result2);
   cache.AddToCache(key3, result3);
@@ -87,8 +92,54 @@ TEST(ShapeCache, AddToCacheAndFind) {
 
 TEST(ShapeCache, Singleton) {
   ShapeCache& cache1 = ShapeCache::GetInstance();
+  cache1.Clear();
   ShapeCache& cache2 = ShapeCache::GetInstance();
   EXPECT_EQ(&cache1, &cache2);
+}
+
+TEST(ShapeCache, InstancesAreIsolated) {
+  ShapeCache cache1;
+  ShapeCache cache2;
+  ShapeKey key(U"instance", 8, FontDescriptor(), 10.f, false, false, false);
+  auto result1 = std::make_shared<ShapeResult>(1, false);
+  auto result2 = std::make_shared<ShapeResult>(1, false);
+
+  cache1.AddToCache(key, result1);
+  EXPECT_EQ(cache1.Find(key), result1);
+  EXPECT_EQ(cache2.Find(key), nullptr);
+
+  cache2.AddToCache(key, result2);
+  EXPECT_EQ(cache1.Find(key), result1);
+  EXPECT_EQ(cache2.Find(key), result2);
+}
+
+TEST(ShapeCache, DuplicateInsertionIsIdempotent) {
+  ShapeCache cache;
+  ShapeKey key(U"duplicate", 9, FontDescriptor(), 10.f, false, false, false);
+  auto original_result = std::make_shared<ShapeResult>(1, false);
+  auto duplicate_result = std::make_shared<ShapeResult>(1, false);
+
+  cache.AddToCache(key, original_result);
+  cache.AddToCache(key, duplicate_result);
+
+  EXPECT_EQ(cache.Find(key), original_result);
+}
+
+TEST(ShapeCache, ConcurrentDuplicateInsertionIsIdempotent) {
+  ShapeCache cache;
+  ShapeKey key(U"concurrent", 10, FontDescriptor(), 10.f, false, false, false);
+  std::vector<std::thread> threads;
+
+  for (int i = 0; i < 8; ++i) {
+    threads.emplace_back([&cache, &key]() {
+      cache.AddToCache(key, std::make_shared<ShapeResult>(1, false));
+    });
+  }
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  EXPECT_NE(cache.Find(key), nullptr);
 }
 
 TEST(ShapeCache, ClearRemovesAllEntries) {
@@ -106,8 +157,7 @@ TEST(ShapeCache, ClearRemovesAllEntries) {
 TEST(ShapeCache, ClearRejectsAnInFlightResultFromThePreviousEpoch) {
   ShapeKey key(U"stale", 5, FontDescriptor(), 10.f, false, false, false);
   auto result = std::make_shared<ShapeResult>(1, false);
-  ShapeCache& cache = ShapeCache::GetInstance();
-  cache.Clear();
+  ShapeCache cache;
 
   ShapeCache::Epoch epoch = 0;
   EXPECT_EQ(cache.Find(key, &epoch), nullptr);
@@ -152,10 +202,9 @@ TEST(ShapeCache, LruCacheCapacity) {
     return ShapeKey(u32str.c_str(), u32str.length(), FontDescriptor(), 10.f,
                     false, false, false);
   };
-  constexpr int kDefaultCapacity =
-      android::LruCache<const ShapeKey,
-                        ShapeResultRef>::Capacity::kDefaultCapacity;
+  constexpr int kDefaultCapacity = 10'000;
   ShapeCache& cache = ShapeCache::GetInstance();
+  cache.Clear();
   const auto dummy_shape_result = std::make_shared<ShapeResult>(1, false);
   // Fill the cache with kDefaultCapacity entries
   for (int i = 0; i < kDefaultCapacity; i++) {

--- a/test/text_layout_test.cc
+++ b/test/text_layout_test.cc
@@ -15,6 +15,7 @@
 #include <utility>
 
 #include "mocks.h"
+#include "src/textlayout/shape_cache.h"
 #include "src/textlayout/style_attributes.h"
 #include "test_utils.h"
 
@@ -129,6 +130,67 @@ class TextLayoutTest : public ::testing::Test {
                            std::move(regions));
   };
 };
+
+TEST_F(TextLayoutTest, GlobalShapeCacheClearApisAreEquivalent) {
+  ShapeCache& cache = ShapeCache::GetInstance();
+  ShapeKey key(U"global clear", 12, FontDescriptor(), 10.f, false, false,
+               false);
+  auto result = std::make_shared<ShapeResult>(1, false);
+
+  cache.Clear();
+  cache.AddToCache(key, result);
+  TextLayout::ClearGlobalShapeCache();
+  EXPECT_EQ(cache.Find(key), nullptr);
+
+  cache.AddToCache(key, result);
+  TextLayout::ClearShapeCache();
+  EXPECT_EQ(cache.Find(key), nullptr);
+}
+
+TEST_F(TextLayoutTest, ClearInstanceShapeCacheClearsOnlyOwnedShaperCache) {
+  auto shaper =
+      std::make_unique<MockTTShaper>(TestUtils::getFontmgrCollection());
+  auto* shaper_ptr = shaper.get();
+  TextLayout layout(std::move(shaper));
+  TTTextContext context;
+  context.SetShapeCacheMode(ShapeCacheMode::kInstance);
+  shaper_ptr->SetContext(context);
+  const std::u32string text = U"instance clear";
+  const ShapeStyle style(FontDescriptor(), 12.f, false, false);
+
+  EXPECT_CALL(*shaper_ptr, OnShapeText(_, _))
+      .Times(3)
+      .WillRepeatedly(Invoke([](const ShapeKey& key, ShapeResult* result) {
+        TestShapingResultReader reader(static_cast<uint32_t>(key.text_.size()));
+        result->AppendPlatformShapingResult(reader);
+      }));
+
+  auto first_result =
+      shaper_ptr->ShapeText(text.c_str(), text.size(), &style, false);
+  auto cached_result =
+      shaper_ptr->ShapeText(text.c_str(), text.size(), &style, false);
+  EXPECT_EQ(first_result, cached_result);
+
+  TextLayout::ClearGlobalShapeCache();
+  auto instance_result_after_global_clear =
+      shaper_ptr->ShapeText(text.c_str(), text.size(), &style, false);
+  EXPECT_EQ(first_result, instance_result_after_global_clear);
+
+  layout.ClearInstanceShapeCache();
+  auto result_after_clear =
+      shaper_ptr->ShapeText(text.c_str(), text.size(), &style, false);
+  EXPECT_NE(first_result, result_after_clear);
+
+  context.SetShapeCacheMode(ShapeCacheMode::kGlobal);
+  TextLayout::ClearGlobalShapeCache();
+  auto global_result =
+      shaper_ptr->ShapeText(text.c_str(), text.size(), &style, false);
+  layout.ClearInstanceShapeCache();
+  auto global_result_after_instance_clear =
+      shaper_ptr->ShapeText(text.c_str(), text.size(), &style, false);
+  EXPECT_EQ(global_result, global_result_after_instance_clear);
+  TextLayout::ClearGlobalShapeCache();
+}
 
 TEST_F(TextLayoutTest, DifferentLayoutModes) {
   const float page_width = 3.f;

--- a/test/tt_shaper_test.cc
+++ b/test/tt_shaper_test.cc
@@ -112,6 +112,11 @@ class AdjacentFlagFontManager final : public IFontManager {
   TypefaceRef second_flag_typeface_;
 };
 
+void AppendTestShapeResult(const ShapeKey& key, ShapeResult* result) {
+  TestShapingResultReader reader(static_cast<uint32_t>(key.text_.size()));
+  result->AppendPlatformShapingResult(reader);
+}
+
 }  // namespace
 
 TEST(ShapeStyle, Constructor) {
@@ -465,6 +470,7 @@ TEST(TTShaper, Constructor) {
 }
 
 TEST(TTShaper, ShapeTextCallsOnShapeText) {
+  ShapeCache::GetInstance().Clear();
   FontmgrCollection font_collection = TestUtils::getFontmgrCollection();
   MockTTShaper mock_shaper(font_collection);
   const std::u32string text = U"test";
@@ -481,6 +487,162 @@ TEST(TTShaper, ShapeTextCallsOnShapeText) {
   auto result = mock_shaper.ShapeText(text.c_str(), text.length(), &style, rtl);
   // Check the returned ShapeResult is set by OnShapeText
   EXPECT_EQ(result->CharCount(), text.length());
+}
+
+TEST(TTShaper, GlobalCacheIsSharedAcrossShapers) {
+  ShapeCache::GetInstance().Clear();
+  FontmgrCollection font_collection = TestUtils::getFontmgrCollection();
+  MockTTShaper first_shaper(font_collection);
+  MockTTShaper second_shaper(font_collection);
+  TTTextContext context;
+  context.SetShapeCacheMode(ShapeCacheMode::kGlobal);
+  first_shaper.SetContext(context);
+  second_shaper.SetContext(context);
+  const std::u32string text = U"global cache";
+  const ShapeStyle style(FontDescriptor(), 12.f, false, false);
+  const ShapeKey key(text.c_str(), text.size(), &style, false);
+
+  EXPECT_CALL(first_shaper, OnShapeText(key, _))
+      .WillOnce(Invoke(AppendTestShapeResult));
+  EXPECT_CALL(second_shaper, OnShapeText(_, _)).Times(0);
+
+  auto first_result =
+      first_shaper.ShapeText(text.c_str(), text.size(), &style, false);
+  auto second_result =
+      second_shaper.ShapeText(text.c_str(), text.size(), &style, false);
+
+  EXPECT_EQ(first_result, second_result);
+}
+
+TEST(TTShaper, InstanceCacheIsIsolatedPerShaper) {
+  ShapeCache::GetInstance().Clear();
+  FontmgrCollection font_collection = TestUtils::getFontmgrCollection();
+  MockTTShaper first_shaper(font_collection);
+  MockTTShaper second_shaper(font_collection);
+  TTTextContext context;
+  context.SetShapeCacheMode(ShapeCacheMode::kInstance);
+  first_shaper.SetContext(context);
+  second_shaper.SetContext(context);
+  const std::u32string text = U"instance cache";
+  const ShapeStyle style(FontDescriptor(), 12.f, false, false);
+  const ShapeKey key(text.c_str(), text.size(), &style, false);
+
+  EXPECT_CALL(first_shaper, OnShapeText(key, _))
+      .WillOnce(Invoke(AppendTestShapeResult));
+  EXPECT_CALL(second_shaper, OnShapeText(key, _))
+      .WillOnce(Invoke(AppendTestShapeResult));
+
+  auto first_result =
+      first_shaper.ShapeText(text.c_str(), text.size(), &style, false);
+  auto first_cached_result =
+      first_shaper.ShapeText(text.c_str(), text.size(), &style, false);
+  auto second_result =
+      second_shaper.ShapeText(text.c_str(), text.size(), &style, false);
+
+  EXPECT_EQ(first_result, first_cached_result);
+  EXPECT_NE(first_result, second_result);
+}
+
+TEST(TTShaper, DisabledCacheAlwaysMissesAndDoesNotPopulateGlobalCache) {
+  ShapeCache::GetInstance().Clear();
+  FontmgrCollection font_collection = TestUtils::getFontmgrCollection();
+  MockTTShaper shaper(font_collection);
+  TTTextContext context;
+  context.SetShapeCacheMode(ShapeCacheMode::kDisabled);
+  shaper.SetContext(context);
+  const std::u32string text = U"disabled cache";
+  const ShapeStyle style(FontDescriptor(), 12.f, false, false);
+  const ShapeKey key(text.c_str(), text.size(), &style, false);
+
+  EXPECT_CALL(shaper, OnShapeText(key, _))
+      .Times(3)
+      .WillRepeatedly(Invoke(AppendTestShapeResult));
+
+  auto first_disabled_result =
+      shaper.ShapeText(text.c_str(), text.size(), &style, false);
+  auto second_disabled_result =
+      shaper.ShapeText(text.c_str(), text.size(), &style, false);
+  EXPECT_NE(first_disabled_result, second_disabled_result);
+
+  context.SetShapeCacheMode(ShapeCacheMode::kGlobal);
+  auto global_result =
+      shaper.ShapeText(text.c_str(), text.size(), &style, false);
+  auto global_cached_result =
+      shaper.ShapeText(text.c_str(), text.size(), &style, false);
+
+  EXPECT_NE(global_result, first_disabled_result);
+  EXPECT_NE(global_result, second_disabled_result);
+  EXPECT_EQ(global_result, global_cached_result);
+}
+
+TEST(TTShaper, SwitchingModesPreservesInstanceCache) {
+  ShapeCache::GetInstance().Clear();
+  FontmgrCollection font_collection = TestUtils::getFontmgrCollection();
+  MockTTShaper shaper(font_collection);
+  TTTextContext context;
+  context.SetShapeCacheMode(ShapeCacheMode::kInstance);
+  shaper.SetContext(context);
+  const std::u32string text = U"preserved instance";
+  const ShapeStyle style(FontDescriptor(), 12.f, false, false);
+  const ShapeKey key(text.c_str(), text.size(), &style, false);
+
+  EXPECT_CALL(shaper, OnShapeText(key, _))
+      .Times(3)
+      .WillRepeatedly(Invoke(AppendTestShapeResult));
+
+  auto instance_result =
+      shaper.ShapeText(text.c_str(), text.size(), &style, false);
+
+  context.SetShapeCacheMode(ShapeCacheMode::kGlobal);
+  auto global_result =
+      shaper.ShapeText(text.c_str(), text.size(), &style, false);
+
+  context.SetShapeCacheMode(ShapeCacheMode::kDisabled);
+  auto disabled_result =
+      shaper.ShapeText(text.c_str(), text.size(), &style, false);
+
+  context.SetShapeCacheMode(ShapeCacheMode::kInstance);
+  auto restored_instance_result =
+      shaper.ShapeText(text.c_str(), text.size(), &style, false);
+
+  EXPECT_NE(instance_result, global_result);
+  EXPECT_NE(instance_result, disabled_result);
+  EXPECT_EQ(instance_result, restored_instance_result);
+}
+
+TEST(TTShaper, ClearShapeCacheOnlyClearsThisShaperInstanceCache) {
+  ShapeCache::GetInstance().Clear();
+  FontmgrCollection font_collection = TestUtils::getFontmgrCollection();
+  MockTTShaper first_shaper(font_collection);
+  MockTTShaper second_shaper(font_collection);
+  TTTextContext context;
+  context.SetShapeCacheMode(ShapeCacheMode::kInstance);
+  first_shaper.SetContext(context);
+  second_shaper.SetContext(context);
+  const std::u32string text = U"clear instance";
+  const ShapeStyle style(FontDescriptor(), 12.f, false, false);
+  const ShapeKey key(text.c_str(), text.size(), &style, false);
+
+  EXPECT_CALL(first_shaper, OnShapeText(key, _))
+      .Times(2)
+      .WillRepeatedly(Invoke(AppendTestShapeResult));
+  EXPECT_CALL(second_shaper, OnShapeText(key, _))
+      .WillOnce(Invoke(AppendTestShapeResult));
+
+  auto first_result =
+      first_shaper.ShapeText(text.c_str(), text.size(), &style, false);
+  auto second_result =
+      second_shaper.ShapeText(text.c_str(), text.size(), &style, false);
+
+  first_shaper.ClearInstanceShapeCache();
+
+  auto first_result_after_clear =
+      first_shaper.ShapeText(text.c_str(), text.size(), &style, false);
+  auto second_result_after_clear =
+      second_shaper.ShapeText(text.c_str(), text.size(), &style, false);
+
+  EXPECT_NE(first_result, first_result_after_clear);
+  EXPECT_EQ(second_result, second_result_after_clear);
 }
 
 TEST(TTShaper, UsesSeparateFallbackFontsForAdjacentFlagClusters) {

--- a/test/tttext_context_test.cc
+++ b/test/tttext_context_test.cc
@@ -47,10 +47,23 @@ TEST_F(TTTextContextTest, ConfigurationGettersAndSetters) {
   EXPECT_EQ(context.IsSkipSpacingBeforeFirstLine(), true);
 }
 
+TEST_F(TTTextContextTest, ShapeCacheModeDefaultsToGlobalAndCanBeChanged) {
+  TTTextContext context;
+
+  EXPECT_EQ(context.GetShapeCacheMode(), ShapeCacheMode::kGlobal);
+
+  context.SetShapeCacheMode(ShapeCacheMode::kInstance);
+  EXPECT_EQ(context.GetShapeCacheMode(), ShapeCacheMode::kInstance);
+
+  context.SetShapeCacheMode(ShapeCacheMode::kDisabled);
+  EXPECT_EQ(context.GetShapeCacheMode(), ShapeCacheMode::kDisabled);
+}
+
 TEST_F(TTTextContextTest, Reset) {
   TTTextContext context;
 
   const float new_layout_bottom = 20.f;
+  context.SetShapeCacheMode(ShapeCacheMode::kInstance);
   TTTextContextTest::SetLayoutPosition(context, 5, 10);
   TTTextContextTest::SetLayoutBottom(context, new_layout_bottom);
   auto result = context.GetLayoutPosition();
@@ -63,6 +76,21 @@ TEST_F(TTTextContextTest, Reset) {
   EXPECT_EQ(result.first, 0);
   EXPECT_EQ(result.second, 0);
   EXPECT_EQ(TTTextContextTest::GetLayoutBottom(context), 0.f);
+  EXPECT_EQ(context.GetShapeCacheMode(), ShapeCacheMode::kInstance);
+}
+
+TEST_F(TTTextContextTest, LegacyShapeCacheFeatureUsesLastCall) {
+  TTTextContext context;
+
+  context.SetShapeCacheMode(ShapeCacheMode::kInstance);
+  context.EnableFeature(kDisableShapeCache, true);
+  EXPECT_EQ(context.GetShapeCacheMode(), ShapeCacheMode::kDisabled);
+
+  context.EnableFeature(kDisableShapeCache, false);
+  EXPECT_EQ(context.GetShapeCacheMode(), ShapeCacheMode::kGlobal);
+
+  context.SetShapeCacheMode(ShapeCacheMode::kInstance);
+  EXPECT_EQ(context.GetShapeCacheMode(), ShapeCacheMode::kInstance);
 }
 
 TEST_F(TTTextContextTest, ResetLayoutPosition) {


### PR DESCRIPTION
## Summary

- add `global`, `instance`, and `disabled` shaping cache modes configured through `TTTextContext`
- keep the existing global behavior as the default and retain `kDisableShapeCache` as a soft-deprecated compatibility option
- add explicit global and per-`TextLayout` cache clearing APIs
- make `ShapeCache` reusable for instance caches while preserving clear epochs and fixing LRU locking / duplicate insertion behavior

## API changes

- add `ShapeCacheMode`
- add `TTTextContext::GetShapeCacheMode()` and `SetShapeCacheMode()`
- add `TextLayout::ClearGlobalShapeCache()` and `ClearInstanceShapeCache()`
- retain `TextLayout::ClearShapeCache()` as the global-cache compatibility alias

## Test plan

- built `lynxtextra` with both `use_lru_cache=true` and `use_lru_cache=false`
- compiled the affected shape cache, shaper, context, and text layout test objects with the repository toolchain
- ran focused runtime smoke tests for global / instance / disabled routing with both cache implementations
- ran focused ThreadSanitizer concurrency smoke tests with both cache implementations
- ran `clang-format --dry-run --Werror`, `git diff --check`, and `ruby -c LynxTextra.podspec`

The full `TextLayoutLiteTest` executable is macOS-only in the current repository configuration and was not run on this Linux host.
