### PR TITLE
[BugFix] Clear self-rendering CoreText safe-font cache in ClearShapeCache

### DIFF
--- a/src/ports/shaper/coretext/shaper_core_text_self_rendering.h
+++ b/src/ports/shaper/coretext/shaper_core_text_self_rendering.h
@@ -44,6 +44,10 @@ class ShaperCoreTextSelfRendering : public TTShaper {
   void OnShapeText(const ShapeKey& key, ShapeResult* result) const override;
   static void SetSafeFontCacheMaxEntries(size_t max_entries);
   static size_t GetSafeFontCacheMaxEntries();
+  // Releases every cached safe font. Callers of GetOrCreateSafeFont own the
+  // reference they received, so dropping the cache's own reference here cannot
+  // invalidate a shaping run that is already in flight.
+  static void ClearSafeFontCache();
 
  private:
   static CTFontDescriptorRef CopyFontDescriptorWithoutCascade(

--- a/src/ports/shaper/coretext/shaper_core_text_self_rendering.mm
+++ b/src/ports/shaper/coretext/shaper_core_text_self_rendering.mm
@@ -194,6 +194,17 @@ size_t ShaperCoreTextSelfRendering::GetSafeFontCacheMaxEntries() {
   return safe_font_cache_max_entries_;
 }
 
+void ShaperCoreTextSelfRendering::ClearSafeFontCache() {
+  std::lock_guard<std::mutex> lock(safe_font_cache_mutex_);
+  for (auto& entry : safe_font_cache_) {
+    if (entry.second.safe_font_ != nullptr) {
+      CFRelease(entry.second.safe_font_);
+    }
+  }
+  safe_font_cache_.clear();
+  safe_font_cache_lru_.clear();
+}
+
 void ShaperCoreTextSelfRendering::TrimSafeFontCacheLocked() {
   while (safe_font_cache_.size() > safe_font_cache_max_entries_) {
     const auto& oldest_key = safe_font_cache_lru_.back();

--- a/src/textlayout/text_layout.cc
+++ b/src/textlayout/text_layout.cc
@@ -25,7 +25,14 @@ TextLayout::~TextLayout() = default;
 
 bool TextLayout::Preload(ShaperType type) { return TTShaper::Preload(type); }
 
-void TextLayout::ClearShapeCache() { ShapeCache::GetInstance().Clear(); }
+void TextLayout::ClearShapeCache() {
+  ShapeCache::GetInstance().Clear();
+  // Shaped results are not the only per-session font state: the self-rendering
+  // CoreText shaper keeps a process-wide safe-font cache whose CTFontRef
+  // entries pin the whole in-memory font file. Drop it here as well, otherwise
+  // clearing the shape cache reclaims almost nothing.
+  TTShaper::ClearFontCache();
+}
 
 LayoutResult TextLayout::LayoutEx(Paragraph* para, LayoutRegion* page,
                                   TTTextContext& context) const {

--- a/src/textlayout/tt_shaper.cc
+++ b/src/textlayout/tt_shaper.cc
@@ -84,6 +84,12 @@ bool TTShaper::Preload(ShaperType type) {
   }
 }
 
+void TTShaper::ClearFontCache() {
+#if defined(ENABLE_CTSHAPER) || defined(ENABLE_CTSHAPER_SKITY)
+  ShaperCoreTextSelfRendering::ClearSafeFontCache();
+#endif
+}
+
 TTShaper::TTShaper(FontmgrCollection font_collection) noexcept
     : font_collection_(font_collection), context_(nullptr) {}
 TTShaper::~TTShaper() = default;

--- a/src/textlayout/tt_shaper.h
+++ b/src/textlayout/tt_shaper.h
@@ -38,6 +38,9 @@ class TTShaper {
   static std::unique_ptr<TTShaper> CreateShaper(
       FontmgrCollection* font_collection, ShaperType type = kSystem);
   static bool Preload(ShaperType type);
+  // Releases platform shaper font caches that outlive individual shapers.
+  // No-op on platforms whose shapers do not keep such a cache.
+  static void ClearFontCache();
 
   const FontmgrCollection& GetFontCollection() const noexcept {
     return font_collection_;


### PR DESCRIPTION
## Problem

`TextLayout::ClearShapeCache()` only cleared `ShapeCache`. The self-rendering
CoreText shaper keeps a *separate*, process-wide `safe_font_cache_` whose
entries hold an owning `CTFontRef`. Each of those pins a `CGFont` and, through
it, the entire in-memory font file.

So a host that registers custom fonts, renders a text session, tears it down and
releases every typeface it owns still could not get the font bytes back —
`ClearShapeCache()` reclaimed the shaped results and essentially nothing else.
Repeating the cycle accumulated font memory linearly.

## Fix

- `ShaperCoreTextSelfRendering::ClearSafeFontCache()` — releases every cached
  `CTFontRef` and empties both the map and its LRU list, under the existing
  cache mutex.
- `TTShaper::ClearFontCache()` — dispatches to it behind the same
  `ENABLE_CTSHAPER`/`ENABLE_CTSHAPER_SKITY` guard the CoreText includes already
  use, mirroring how `Preload` is routed.
- `TextLayout::ClearShapeCache()` calls it.

Capacity is untouched, so the cache repopulates as usual after a clear.

## Why this is safe

`GetOrCreateSafeFont` retains the font it hands back on *every* return path —
the fast cache hit, the re-locked race-loser hit, the caching-disabled path, and
the create path (where the map takes the create-rule +1 and the caller gets a
second retain). Both call sites hand the font straight to a CF container that
retains independently, then release their own reference.

So the caller always owns what it received, and dropping the cache's reference
cannot invalidate a shaping run that is already in flight.

Two more checks: `CachedSafeFontEntry` is a plain aggregate with no destructor,
so the explicit `CFRelease` is not a double-release; and the release discipline
here is identical to the existing `TrimSafeFontCacheLocked()`, which also pops
the LRU list.

## Scope

Deliberately limited to the self-rendering path.

`ShaperCoreText` declares its own separate `safe_font_cache_` and is left
completely untouched, so `kSystem` callers keep exactly the behavior they have
today. That matches the isolation `CreateShaper` already documents:

> Ordered CoreText family matching is intentionally isolated to the
> self-rendering path. Keep kSystem on the legacy shaper so TextService and
> other system-rendered callers retain their existing behavior.

Worth stating plainly for reviewers: after this change there is still no
reachable API to drop `ShaperCoreText`'s cache — `SetSafeFontCacheMaxEntries`
has no callers and the class is not exported through `public/textra`. That is
unchanged from today's behavior, not a regression introduced here, but it is a
gap if someone later wants the same reclamation for `kSystem`.

## Test

- `clang -fsyntax-only`, `arm64-apple-ios`, `ENABLE_CTSHAPER`, on
  `text_layout.cc`, `tt_shaper.cc` and `shaper_core_text_self_rendering.mm` —
  clean, no new warnings (the 4 pre-existing `__bridge_retained` warnings are
  unchanged), and `clang-format` reports no violations on any added line.
- Downstream iOS integration, entering and leaving a text session 10x and 20x
  and diffing memory graphs against a baseline. Before: retained in-memory fonts
  grew linearly with the cycle count. After: the count is flat, with a single
  entry rotating per session and every font-class delta between the 10x and 20x
  runs zero or negative.

One caveat on that second measurement: the build it was taken on also carried
the `ShaperCoreText` half of this change, which this PR drops. That app shapes
through `kSelfRendering`, so the self-rendering clear is the operative part —
but the number was not re-measured against this exact reduced patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
