### PR TITLE
[Optimize] Build bidirectional maps once per paragraph

### DIFF
--- a/src/textlayout/icu_substitute/bidi/bidi_wrapper.cc
+++ b/src/textlayout/icu_substitute/bidi/bidi_wrapper.cc
@@ -26,10 +26,12 @@ void BidiWrapper::SetPara(const char32_t* u32_content, const uint32_t& length,
       direction == tttext::WriteDirection::kBTT)
     para_level = 1;
   bidi_->setPara(u32_content, para_level, std::vector<int16_t>());
+  const auto visual_indices = bidi_->getVisualMap();
+  const auto logical_indices = bidi_->getLogicalMap();
   for (int k = 0; k < static_cast<int>(length); k++) {
     bidi_levels[k] = bidi_->getLevelAt(k);
-    visual_map[k] = bidi_->getVisualMap()[k];
-    logical_map[k] = bidi_->getLogicalMap()[k];
+    visual_map[k] = visual_indices[k];
+    logical_map[k] = logical_indices[k];
   }
 }
 }  // namespace tttext

--- a/test/tt_shaper_test.cc
+++ b/test/tt_shaper_test.cc
@@ -13,11 +13,13 @@
 #include <numeric>
 #include <unordered_set>
 #include <utility>
+#include <vector>
 
 #if defined(ENABLE_CTSHAPER)
 #include "src/ports/shaper/coretext/shaper_core_text_self_rendering.h"
 #endif
 #include "mocks.h"
+#include "src/textlayout/icu_substitute/bidi/bidi_wrapper.h"
 #include "src/textlayout/shape_cache.h"
 #include "test_utils.h"
 
@@ -113,6 +115,42 @@ class AdjacentFlagFontManager final : public IFontManager {
 };
 
 }  // namespace
+
+TEST(BidiWrapper, BuildsMapsForLongParagraph) {
+  constexpr uint32_t kTextLength = 10000;
+  const std::u32string text(kTextLength, U'a');
+  std::vector<uint8_t> bidi_levels(kTextLength);
+  std::vector<uint32_t> visual_map(kTextLength);
+  std::vector<uint32_t> logical_map(kTextLength);
+
+  BidiWrapper::GetInstance().SetPara(text.data(), kTextLength,
+                                     WriteDirection::kLTR, bidi_levels.data(),
+                                     visual_map.data(), logical_map.data());
+
+  for (uint32_t index = 0; index < kTextLength; ++index) {
+    EXPECT_EQ(bidi_levels[index], 0u);
+    EXPECT_EQ(visual_map[index], index);
+    EXPECT_EQ(logical_map[index], index);
+  }
+}
+
+TEST(BidiWrapper, BuildsInverseMapsForMixedDirectionText) {
+  const std::u32string text = U"abc \u05D0\u05D1\u05D2 def";
+  std::vector<uint8_t> bidi_levels(text.size());
+  std::vector<uint32_t> visual_map(text.size());
+  std::vector<uint32_t> logical_map(text.size());
+
+  BidiWrapper::GetInstance().SetPara(text.data(), text.size(),
+                                     WriteDirection::kLTR, bidi_levels.data(),
+                                     visual_map.data(), logical_map.data());
+
+  EXPECT_EQ(bidi_levels[4], 1u);
+  EXPECT_EQ(bidi_levels[5], 1u);
+  EXPECT_EQ(bidi_levels[6], 1u);
+  for (uint32_t index = 0; index < text.size(); ++index) {
+    EXPECT_EQ(logical_map[visual_map[index]], index);
+  }
+}
 
 TEST(ShapeStyle, Constructor) {
   FontDescriptor font_descriptor;


### PR DESCRIPTION
## Summary

- build the paragraph visual and logical Bidi maps once before copying entries to the caller
- reduce long-paragraph map construction from quadratic to linear work
- preserve Bidi levels and visual/logical ordering, with regression coverage for 10k LTR text and mixed RTL/LTR text

## Root cause

`Bidi::getVisualMap()` and `Bidi::getLogicalMap()` each construct and return a complete map. `BidiWrapper::SetPara()` called both accessors once per character, rebuilding the full maps `length` times.

## Testing

- PASS: compiled and ran `BidiWrapper` with the complete substitute Bidi algorithm; verified a 10k-character LTR paragraph and mixed RTL/LTR levels plus inverse maps
- PASS: `git lynx check` coding-style and android-check-style stages
- BLOCKED (repository tooling): the API checker raises a `NoneType` error because the public checker configuration has no Android API directory; the full macOS test target also hits existing Skity/libpng ARM64 build issues
