### PR TITLE
[BugFix] exclude ghost runs from character range bounds

### DIFF
--- a/src/textlayout/text_line_impl.cc
+++ b/src/textlayout/text_line_impl.cc
@@ -550,15 +550,6 @@ std::vector<RectF> TextLineImpl::GetCharRangeBounds(CharPos start_char_pos,
   float tight_left{0}, tight_right{0}, tight_ascent{0}, tight_descent{0};
   for (auto& drawer : drawer_list_) {
     if (drawer->GetRun()->IsGhostRun()) {
-      if (bounds_available) {
-        auto metrics = drawer->GetRun()->GetMetrics();
-        current_right = drawer->GetRight();
-        float local_baseline = drawer->GetYOffsetInLine() + y_base;
-        current_top =
-            std::min(current_top, local_baseline + metrics.GetMaxAscent());
-        current_bottom =
-            std::max(current_bottom, local_baseline + metrics.GetMaxDescent());
-      }
       continue;
     }
     auto drawer_start = drawer->GetStartCharPosInParagraph();

--- a/test/text_test.cc
+++ b/test/text_test.cc
@@ -322,5 +322,6 @@ TEST(TextTest, EllipsisWithIndentTest) {
   line->GetBoundingRectByCharRange(rect, line->GetStartCharPos(),
                                    line->GetEndCharPos());
   EXPECT_EQ(rect[0], 20.f);
-  EXPECT_EQ(rect[2], 80.f);
+  // Character range bounds exclude the ellipsis ghost run.
+  EXPECT_EQ(rect[2], 50.f);
 }


### PR DESCRIPTION
Skip ghost runs when calculating character bounding rectangles so their dimensions are not attributed to adjacent text characters.