### PR TITLE
[Feature] Enable Skity subpixel text positioning

### DIFF
--- a/public/textra/platform/skity/skity_canvas_helper.h
+++ b/public/textra/platform/skity/skity_canvas_helper.h
@@ -96,6 +96,8 @@ class SkityCanvasHelper : public ICanvasHelper {
     }
     std::vector<skity::TextRun> runs;
     skity::Font skity_font(typeface->GetTypeface(), paint->GetTextSize());
+    skity_font.SetSubpixel(true);
+    skity_font.SetBaselineSnap(true);
     skity_font.SetHinting(skity::Font::FontHinting::kSlight);
     skity_font.SetEmbolden(painter->IsBold());
     skity_font.SetSkewX((painter->IsItalic() ? FAKE_ITALIC_SKEW : 0) +


### PR DESCRIPTION
Enable subpixel positioning and baseline snapping for fonts created by SkityCanvasHelper, allowing Skity to preserve fractional glyph positions.