### PR TITLE
[BugFix] avoid CoreText safe font cache initialization crash

### DIFF
--- a/src/ports/shaper/coretext/shaper_core_text.h
+++ b/src/ports/shaper/coretext/shaper_core_text.h
@@ -67,6 +67,15 @@ class ShaperCoreText : public TTShaper {
     std::list<CachedSafeFontKey>::iterator lru_it_;
   };
 
+  struct SafeFontCacheState {
+    std::unordered_map<CachedSafeFontKey, CachedSafeFontEntry,
+                       CachedSafeFontKey::Hasher>
+        cache_;
+    std::list<CachedSafeFontKey> lru_;
+    std::mutex mutex_;
+    size_t max_entries_ = 256;
+  };
+
   CFAttributedStringRef GenerateAttributeString(const char16_t* content,
                                                 uint32_t length,
                                                 uint32_t* u16char_map,
@@ -75,17 +84,12 @@ class ShaperCoreText : public TTShaper {
   CTFontRef CreateSafeFontUnified(CTFontRef existing_font) const;
   CTFontRef GetOrCreateSafeFont(const FontDescriptor& fd, float text_size,
                                 bool fake_bold, bool fake_italic) const;
-  static void TrimSafeFontCacheLocked();
+  static SafeFontCacheState& GetSafeFontCacheState();
+  static void TrimSafeFontCacheLocked(SafeFontCacheState& state);
 
  private:
   mutable std::vector<TypefaceRef> ct_font_lst_;
   mutable uint32_t tmp_buf_[SHAPER_BUFF_SIZE];
-  static std::unordered_map<CachedSafeFontKey, CachedSafeFontEntry,
-                            CachedSafeFontKey::Hasher>
-      safe_font_cache_;
-  static std::list<CachedSafeFontKey> safe_font_cache_lru_;
-  static std::mutex safe_font_cache_mutex_;
-  static size_t safe_font_cache_max_entries_;
 };
 }  // namespace tttext
 }  // namespace ttoffice

--- a/src/ports/shaper/coretext/shaper_core_text.mm
+++ b/src/ports/shaper/coretext/shaper_core_text.mm
@@ -34,15 +34,6 @@
 
 namespace ttoffice {
 namespace tttext {
-std::unordered_map<ShaperCoreText::CachedSafeFontKey,
-                   ShaperCoreText::CachedSafeFontEntry,
-                   ShaperCoreText::CachedSafeFontKey::Hasher>
-    ShaperCoreText::safe_font_cache_;
-std::list<ShaperCoreText::CachedSafeFontKey>
-    ShaperCoreText::safe_font_cache_lru_;
-std::mutex ShaperCoreText::safe_font_cache_mutex_;
-size_t ShaperCoreText::safe_font_cache_max_entries_ = 256;
-
 namespace {
 
 CFDictionaryRef GetSafeFontCascadeAttributes() {
@@ -136,28 +127,39 @@ ShaperCoreText::ShaperCoreText(FontmgrCollection& font_collection) noexcept
 
 ShaperCoreText::~ShaperCoreText() = default;
 
+ShaperCoreText::SafeFontCacheState& ShaperCoreText::GetSafeFontCacheState() {
+  // This cache can be reached from app-load warm-up work before namespace-scope
+  // C++ objects in this translation unit have finished initialization. Create
+  // the whole state on first use and intentionally keep it for process life so
+  // neither startup nor shutdown ordering can invalidate its containers.
+  static SafeFontCacheState* state = new SafeFontCacheState();
+  return *state;
+}
+
 void ShaperCoreText::SetSafeFontCacheMaxEntries(size_t max_entries) {
-  std::lock_guard<std::mutex> lock(safe_font_cache_mutex_);
-  safe_font_cache_max_entries_ = max_entries;
-  TrimSafeFontCacheLocked();
+  auto& state = GetSafeFontCacheState();
+  std::lock_guard<std::mutex> lock(state.mutex_);
+  state.max_entries_ = max_entries;
+  TrimSafeFontCacheLocked(state);
 }
 
 size_t ShaperCoreText::GetSafeFontCacheMaxEntries() {
-  std::lock_guard<std::mutex> lock(safe_font_cache_mutex_);
-  return safe_font_cache_max_entries_;
+  auto& state = GetSafeFontCacheState();
+  std::lock_guard<std::mutex> lock(state.mutex_);
+  return state.max_entries_;
 }
 
-void ShaperCoreText::TrimSafeFontCacheLocked() {
-  while (safe_font_cache_.size() > safe_font_cache_max_entries_) {
-    const auto& oldest_key = safe_font_cache_lru_.back();
-    auto iter = safe_font_cache_.find(oldest_key);
-    if (iter != safe_font_cache_.end()) {
+void ShaperCoreText::TrimSafeFontCacheLocked(SafeFontCacheState& state) {
+  while (state.cache_.size() > state.max_entries_) {
+    const auto& oldest_key = state.lru_.back();
+    auto iter = state.cache_.find(oldest_key);
+    if (iter != state.cache_.end()) {
       if (iter->second.safe_font_ != nullptr) {
         CFRelease(iter->second.safe_font_);
       }
-      safe_font_cache_.erase(iter);
+      state.cache_.erase(iter);
     }
-    safe_font_cache_lru_.pop_back();
+    state.lru_.pop_back();
   }
 }
 
@@ -185,13 +187,13 @@ CTFontRef ShaperCoreText::GetOrCreateSafeFont(const FontDescriptor& fd,
                                               float text_size, bool fake_bold,
                                               bool fake_italic) const {
   CachedSafeFontKey cache_key{fd, text_size, fake_bold, fake_italic};
+  auto& state = GetSafeFontCacheState();
   {
-    std::lock_guard<std::mutex> lock(safe_font_cache_mutex_);
-    auto iter = safe_font_cache_.find(cache_key);
-    if (iter != safe_font_cache_.end()) {
-      safe_font_cache_lru_.splice(safe_font_cache_lru_.begin(),
-                                  safe_font_cache_lru_, iter->second.lru_it_);
-      iter->second.lru_it_ = safe_font_cache_lru_.begin();
+    std::lock_guard<std::mutex> lock(state.mutex_);
+    auto iter = state.cache_.find(cache_key);
+    if (iter != state.cache_.end()) {
+      state.lru_.splice(state.lru_.begin(), state.lru_, iter->second.lru_it_);
+      iter->second.lru_it_ = state.lru_.begin();
       return static_cast<CTFontRef>(CFRetain(iter->second.safe_font_));
     }
   }
@@ -271,24 +273,23 @@ CTFontRef ShaperCoreText::GetOrCreateSafeFont(const FontDescriptor& fd,
     return nullptr;
   }
 
-  std::lock_guard<std::mutex> lock(safe_font_cache_mutex_);
-  auto iter = safe_font_cache_.find(cache_key);
-  if (iter != safe_font_cache_.end()) {
+  std::lock_guard<std::mutex> lock(state.mutex_);
+  auto iter = state.cache_.find(cache_key);
+  if (iter != state.cache_.end()) {
     CFRelease(safe_font);
-    safe_font_cache_lru_.splice(safe_font_cache_lru_.begin(),
-                                safe_font_cache_lru_, iter->second.lru_it_);
-    iter->second.lru_it_ = safe_font_cache_lru_.begin();
+    state.lru_.splice(state.lru_.begin(), state.lru_, iter->second.lru_it_);
+    iter->second.lru_it_ = state.lru_.begin();
     return static_cast<CTFontRef>(CFRetain(iter->second.safe_font_));
   }
 
-  if (safe_font_cache_max_entries_ == 0) {
+  if (state.max_entries_ == 0) {
     return safe_font;
   }
 
-  safe_font_cache_lru_.push_front(cache_key);
-  safe_font_cache_.emplace(
-      cache_key, CachedSafeFontEntry{safe_font, safe_font_cache_lru_.begin()});
-  TrimSafeFontCacheLocked();
+  state.lru_.push_front(cache_key);
+  state.cache_.emplace(cache_key,
+                       CachedSafeFontEntry{safe_font, state.lru_.begin()});
+  TrimSafeFontCacheLocked(state);
   return static_cast<CTFontRef>(CFRetain(safe_font));
 }
 

--- a/src/ports/shaper/coretext/shaper_core_text_self_rendering.h
+++ b/src/ports/shaper/coretext/shaper_core_text_self_rendering.h
@@ -95,6 +95,15 @@ class ShaperCoreTextSelfRendering : public TTShaper {
     std::list<CachedSafeFontKey>::iterator lru_it_;
   };
 
+  struct SafeFontCacheState {
+    std::unordered_map<CachedSafeFontKey, CachedSafeFontEntry,
+                       CachedSafeFontKey::Hasher>
+        cache_;
+    std::list<CachedSafeFontKey> lru_;
+    std::mutex mutex_;
+    size_t max_entries_ = 256;
+  };
+
   CFAttributedStringRef GenerateAttributeString(const char16_t* content,
                                                 uint32_t length,
                                                 uint32_t* u16char_map,
@@ -108,17 +117,12 @@ class ShaperCoreTextSelfRendering : public TTShaper {
       const std::vector<TypefaceRef>& resolved_typefaces) const;
   CTFontRef GetOrCreateSafeFont(const FontDescriptor& fd, float text_size,
                                 bool fake_bold, bool fake_italic) const;
-  static void TrimSafeFontCacheLocked();
+  static SafeFontCacheState& GetSafeFontCacheState();
+  static void TrimSafeFontCacheLocked(SafeFontCacheState& state);
 
  private:
   mutable std::vector<TypefaceRef> ct_font_lst_;
   mutable uint32_t tmp_buf_[SELF_RENDERING_SHAPER_BUFF_SIZE];
-  static std::unordered_map<CachedSafeFontKey, CachedSafeFontEntry,
-                            CachedSafeFontKey::Hasher>
-      safe_font_cache_;
-  static std::list<CachedSafeFontKey> safe_font_cache_lru_;
-  static std::mutex safe_font_cache_mutex_;
-  static size_t safe_font_cache_max_entries_;
 };
 }  // namespace tttext
 }  // namespace ttoffice

--- a/src/ports/shaper/coretext/shaper_core_text_self_rendering.mm
+++ b/src/ports/shaper/coretext/shaper_core_text_self_rendering.mm
@@ -34,15 +34,6 @@
 
 namespace ttoffice {
 namespace tttext {
-std::unordered_map<ShaperCoreTextSelfRendering::CachedSafeFontKey,
-                   ShaperCoreTextSelfRendering::CachedSafeFontEntry,
-                   ShaperCoreTextSelfRendering::CachedSafeFontKey::Hasher>
-    ShaperCoreTextSelfRendering::safe_font_cache_;
-std::list<ShaperCoreTextSelfRendering::CachedSafeFontKey>
-    ShaperCoreTextSelfRendering::safe_font_cache_lru_;
-std::mutex ShaperCoreTextSelfRendering::safe_font_cache_mutex_;
-size_t ShaperCoreTextSelfRendering::safe_font_cache_max_entries_ = 256;
-
 namespace {
 
 void AppendSafeFontCascadeDescriptors(CFMutableArrayRef descriptors) {
@@ -182,40 +173,53 @@ ShaperCoreTextSelfRendering::ShaperCoreTextSelfRendering(
 
 ShaperCoreTextSelfRendering::~ShaperCoreTextSelfRendering() = default;
 
+ShaperCoreTextSelfRendering::SafeFontCacheState&
+ShaperCoreTextSelfRendering::GetSafeFontCacheState() {
+  // Keep the cache valid even when app-load warm-up code reaches the shaper
+  // before namespace-scope C++ initialization, or while global teardown is in
+  // progress. Function-local initialization is thread-safe since C++11.
+  static SafeFontCacheState* state = new SafeFontCacheState();
+  return *state;
+}
+
 void ShaperCoreTextSelfRendering::SetSafeFontCacheMaxEntries(
     size_t max_entries) {
-  std::lock_guard<std::mutex> lock(safe_font_cache_mutex_);
-  safe_font_cache_max_entries_ = max_entries;
-  TrimSafeFontCacheLocked();
+  auto& state = GetSafeFontCacheState();
+  std::lock_guard<std::mutex> lock(state.mutex_);
+  state.max_entries_ = max_entries;
+  TrimSafeFontCacheLocked(state);
 }
 
 size_t ShaperCoreTextSelfRendering::GetSafeFontCacheMaxEntries() {
-  std::lock_guard<std::mutex> lock(safe_font_cache_mutex_);
-  return safe_font_cache_max_entries_;
+  auto& state = GetSafeFontCacheState();
+  std::lock_guard<std::mutex> lock(state.mutex_);
+  return state.max_entries_;
 }
 
 void ShaperCoreTextSelfRendering::ClearSafeFontCache() {
-  std::lock_guard<std::mutex> lock(safe_font_cache_mutex_);
-  for (auto& entry : safe_font_cache_) {
+  auto& state = GetSafeFontCacheState();
+  std::lock_guard<std::mutex> lock(state.mutex_);
+  for (auto& entry : state.cache_) {
     if (entry.second.safe_font_ != nullptr) {
       CFRelease(entry.second.safe_font_);
     }
   }
-  safe_font_cache_.clear();
-  safe_font_cache_lru_.clear();
+  state.cache_.clear();
+  state.lru_.clear();
 }
 
-void ShaperCoreTextSelfRendering::TrimSafeFontCacheLocked() {
-  while (safe_font_cache_.size() > safe_font_cache_max_entries_) {
-    const auto& oldest_key = safe_font_cache_lru_.back();
-    auto iter = safe_font_cache_.find(oldest_key);
-    if (iter != safe_font_cache_.end()) {
+void ShaperCoreTextSelfRendering::TrimSafeFontCacheLocked(
+    SafeFontCacheState& state) {
+  while (state.cache_.size() > state.max_entries_) {
+    const auto& oldest_key = state.lru_.back();
+    auto iter = state.cache_.find(oldest_key);
+    if (iter != state.cache_.end()) {
       if (iter->second.safe_font_ != nullptr) {
         CFRelease(iter->second.safe_font_);
       }
-      safe_font_cache_.erase(iter);
+      state.cache_.erase(iter);
     }
-    safe_font_cache_lru_.pop_back();
+    state.lru_.pop_back();
   }
 }
 
@@ -272,13 +276,13 @@ CTFontRef ShaperCoreTextSelfRendering::GetOrCreateSafeFont(
     const FontDescriptor& fd, float text_size, bool fake_bold,
     bool fake_italic) const {
   CachedSafeFontKey cache_key{fd, text_size, fake_bold, fake_italic};
+  auto& state = GetSafeFontCacheState();
   {
-    std::lock_guard<std::mutex> lock(safe_font_cache_mutex_);
-    auto iter = safe_font_cache_.find(cache_key);
-    if (iter != safe_font_cache_.end()) {
-      safe_font_cache_lru_.splice(safe_font_cache_lru_.begin(),
-                                  safe_font_cache_lru_, iter->second.lru_it_);
-      iter->second.lru_it_ = safe_font_cache_lru_.begin();
+    std::lock_guard<std::mutex> lock(state.mutex_);
+    auto iter = state.cache_.find(cache_key);
+    if (iter != state.cache_.end()) {
+      state.lru_.splice(state.lru_.begin(), state.lru_, iter->second.lru_it_);
+      iter->second.lru_it_ = state.lru_.begin();
       return static_cast<CTFontRef>(CFRetain(iter->second.safe_font_));
     }
   }
@@ -372,24 +376,23 @@ CTFontRef ShaperCoreTextSelfRendering::GetOrCreateSafeFont(
     return nullptr;
   }
 
-  std::lock_guard<std::mutex> lock(safe_font_cache_mutex_);
-  auto iter = safe_font_cache_.find(cache_key);
-  if (iter != safe_font_cache_.end()) {
+  std::lock_guard<std::mutex> lock(state.mutex_);
+  auto iter = state.cache_.find(cache_key);
+  if (iter != state.cache_.end()) {
     CFRelease(safe_font);
-    safe_font_cache_lru_.splice(safe_font_cache_lru_.begin(),
-                                safe_font_cache_lru_, iter->second.lru_it_);
-    iter->second.lru_it_ = safe_font_cache_lru_.begin();
+    state.lru_.splice(state.lru_.begin(), state.lru_, iter->second.lru_it_);
+    iter->second.lru_it_ = state.lru_.begin();
     return static_cast<CTFontRef>(CFRetain(iter->second.safe_font_));
   }
 
-  if (safe_font_cache_max_entries_ == 0) {
+  if (state.max_entries_ == 0) {
     return safe_font;
   }
 
-  safe_font_cache_lru_.push_front(cache_key);
-  safe_font_cache_.emplace(
-      cache_key, CachedSafeFontEntry{safe_font, safe_font_cache_lru_.begin()});
-  TrimSafeFontCacheLocked();
+  state.lru_.push_front(cache_key);
+  state.cache_.emplace(cache_key,
+                       CachedSafeFontEntry{safe_font, state.lru_.begin()});
+  TrimSafeFontCacheLocked(state);
   return static_cast<CTFontRef>(CFRetain(safe_font));
 }
 

--- a/test/tt_shaper_test.cc
+++ b/test/tt_shaper_test.cc
@@ -16,6 +16,7 @@
 #include <vector>
 
 #if defined(ENABLE_CTSHAPER)
+#include "src/ports/shaper/coretext/shaper_core_text.h"
 #include "src/ports/shaper/coretext/shaper_core_text_self_rendering.h"
 #endif
 #include "mocks.h"
@@ -311,6 +312,23 @@ TEST(ShaperCoreTextSelfRendering, CacheKeyUsesFamilyOrder) {
       descriptor_ab, descriptor_ba));
   EXPECT_NE(ShaperCoreTextSelfRenderingTestAccess::CacheKeyHash(descriptor_ab),
             ShaperCoreTextSelfRenderingTestAccess::CacheKeyHash(descriptor_ba));
+}
+
+TEST(ShaperCoreText, SafeFontCacheConfigurationRemainsIndependent) {
+  const size_t system_max_entries =
+      ShaperCoreText::GetSafeFontCacheMaxEntries();
+  const size_t self_rendering_max_entries =
+      ShaperCoreTextSelfRendering::GetSafeFontCacheMaxEntries();
+
+  ShaperCoreText::SetSafeFontCacheMaxEntries(17);
+  ShaperCoreTextSelfRendering::SetSafeFontCacheMaxEntries(23);
+
+  EXPECT_EQ(ShaperCoreText::GetSafeFontCacheMaxEntries(), 17u);
+  EXPECT_EQ(ShaperCoreTextSelfRendering::GetSafeFontCacheMaxEntries(), 23u);
+
+  ShaperCoreText::SetSafeFontCacheMaxEntries(system_max_entries);
+  ShaperCoreTextSelfRendering::SetSafeFontCacheMaxEntries(
+      self_rendering_max_entries);
 }
 
 TEST(ShaperCoreTextSelfRendering,


### PR DESCRIPTION
Move CoreText safe font cache state to function-local process-lifetime singletons to avoid static initialization and destruction order issues.

Apply the fix to both system and self-rendering CoreText shapers, and add coverage for their independent cache configurations.