### PR TITLE
[Optimize] Reduce Android text rendering tail latency

### DIFF
--- a/demos/android/app/src/main/java/com/lynx/textra/demo/MainActivity.java
+++ b/demos/android/app/src/main/java/com/lynx/textra/demo/MainActivity.java
@@ -5,12 +5,10 @@
 package com.lynx.textra.demo;
 
 import android.os.Bundle;
-import android.util.DisplayMetrics;
 import android.view.MenuItem;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.FragmentManager;
 import com.lynx.textra.TTText;
-import com.lynx.textra.TTTextUtils;
 
 public class MainActivity extends AppCompatActivity {
   static {
@@ -25,11 +23,6 @@ public class MainActivity extends AppCompatActivity {
 
     // Set ActionBar
     getSupportActionBar().setTitle("LynxTextra Demo");
-
-    // Initialize DPI
-    DisplayMetrics metrics = new DisplayMetrics();
-    getWindowManager().getDefaultDisplay().getMetrics(metrics);
-    TTTextUtils.SetDpi(metrics.densityDpi / 2);
 
     // If first creation, show list Fragment
     if (savedInstanceState == null) {

--- a/demos/android/app/src/main/java/com/lynx/textra/demo/PageView.java
+++ b/demos/android/app/src/main/java/com/lynx/textra/demo/PageView.java
@@ -17,7 +17,6 @@ import androidx.annotation.Nullable;
 import com.lynx.textra.JavaCanvasHelper;
 import com.lynx.textra.JavaFontManager;
 import com.lynx.textra.TTTextDefinition;
-import com.lynx.textra.TTTextUtils;
 
 public class PageView extends View implements IDrawerCallback {
   private JavaDrawerCallback drawer;
@@ -25,7 +24,8 @@ public class PageView extends View implements IDrawerCallback {
   private byte[] mDrawBuffer;
   private final float x_ = getContext().getResources().getDisplayMetrics().widthPixels * 0.01f;
   private final float y_ = getContext().getResources().getDisplayMetrics().heightPixels * 0.01f;
-  private final float width_ = getContext().getResources().getDisplayMetrics().widthPixels * 0.98f;
+  private final float width_px_ =
+      getContext().getResources().getDisplayMetrics().widthPixels * 0.98f;
   private final float height_ =
       getContext().getResources().getDisplayMetrics().heightPixels * 0.95f;
   MainActivity activity;
@@ -83,8 +83,7 @@ public class PageView extends View implements IDrawerCallback {
    * Set C++ test case and update draw buffer
    */
   public void setCppTestCase(int case_id) {
-    mDrawBuffer =
-        drawCppTestCase(font_manager.GetNativeHandler(), case_id, TTTextUtils.Px2Dp(width_));
+    mDrawBuffer = drawCppTestCase(font_manager.GetNativeHandler(), case_id, width_px_);
     invalidate();
   }
 
@@ -92,14 +91,14 @@ public class PageView extends View implements IDrawerCallback {
    * Set JSON test case and update draw buffer
    */
   public void setJsonTestCase(byte[] jsonBytes) {
-    mDrawBuffer =
-        drawJsonTestCase(font_manager.GetNativeHandler(), jsonBytes, TTTextUtils.Px2Dp(width_));
+    mDrawBuffer = drawJsonTestCase(font_manager.GetNativeHandler(), jsonBytes, width_px_);
     invalidate();
   }
 
-  private native byte[] drawCppTestCase(long font_manager_handler, int case_id, float width);
+  private native byte[] drawCppTestCase(long font_manager_handler, int case_id, float width_px);
 
-  private native byte[] drawJsonTestCase(long font_manager_handler, byte[] jsonBytes, float width);
+  private native byte[] drawJsonTestCase(
+      long font_manager_handler, byte[] jsonBytes, float width_px);
 
   @Override
   public int fetchThemeColor(TTTextDefinition.ThemeColorType type, String extra) {

--- a/demos/android/app/src/main/jni/android_test.cc
+++ b/demos/android/app/src/main/jni/android_test.cc
@@ -35,13 +35,14 @@ Java_com_lynx_textra_demo_PageView_getCppTestList(JNIEnv* env, jclass clazz) {
 extern "C" JNIEXPORT jbyteArray JNICALL
 Java_com_lynx_textra_demo_PageView_drawCppTestCase(JNIEnv* env, jobject thiz,
                                                    jlong font_manager_handler,
-                                                   jint case_id, float width) {
+                                                   jint case_id,
+                                                   float width_px) {
   auto java_font_manager =
       ((JavaFontManager*)font_manager_handler)->shared_from_this();
   JavaCanvasHelper canvas_helper;
   tttext::FontmgrCollection font_collection(java_font_manager);
   ParagraphTest paragraph_test(kSystem, &font_collection);
-  paragraph_test.TestWithId(&canvas_helper, width, case_id);
+  paragraph_test.TestWithId(&canvas_helper, width_px, case_id);
   auto& buffer = canvas_helper.GetBuffer();
   auto* data = buffer.GetBuffer();
   auto length = buffer.GetSize();

--- a/demos/android/app/src/main/jni/tttext_global_config.h
+++ b/demos/android/app/src/main/jni/tttext_global_config.h
@@ -16,8 +16,6 @@ class L_EXPORT TTTextGlobalConfig {
     static TTTextGlobalConfig config;
     return config;
   }
-  float GetDpi() const { return dpi_; }
-  void SetDpi(float dpi) { dpi_ = dpi; }
 
   bool IsAndroidEnableLayoutCache() const {
     return android_enable_layout_cache;
@@ -27,7 +25,6 @@ class L_EXPORT TTTextGlobalConfig {
   }
 
  private:
-  float dpi_{};
   bool android_enable_layout_cache{true};
 };
 }  // namespace illusion

--- a/demos/android/app/src/main/jni/tttext_native.cc
+++ b/demos/android/app/src/main/jni/tttext_native.cc
@@ -42,7 +42,7 @@ extern "C" JNIEXPORT jbyteArray JNICALL
 Java_com_lynx_textra_demo_PageView_drawJsonTestCase(JNIEnv* env, jobject thiz,
                                                     jlong font_manager_handler,
                                                     jbyteArray jsonBytes,
-                                                    jfloat width) {
+                                                    jfloat width_px) {
   jsize length = env->GetArrayLength(jsonBytes);
   jbyte* bytes = env->GetByteArrayElements(jsonBytes, nullptr);
   std::string jsonString(reinterpret_cast<char*>(bytes), length);
@@ -52,11 +52,11 @@ Java_com_lynx_textra_demo_PageView_drawJsonTestCase(JNIEnv* env, jobject thiz,
   auto& regions_from_json = jsonDoc->layout_regions_;
   if (regions_from_json.empty()) {
     regions_from_json.emplace_back(std::make_unique<LayoutRegion>(
-        width, kDefaultHeight, kDefaultWidthMode, kDefaultHeightMode));
+        width_px, kDefaultHeight, kDefaultWidthMode, kDefaultHeightMode));
   } else {
     auto& old_region = regions_from_json[0];
     auto new_region = std::make_unique<LayoutRegion>(
-        width, old_region->GetPageHeight(), old_region->GetWidthMode(),
+        width_px, old_region->GetPageHeight(), old_region->GetWidthMode(),
         old_region->GetHeightMode());
     old_region = std::move(new_region);
   }

--- a/platform/android/lynxtextra/src/main/java/com/lynx/textra/JavaCanvasHelper.java
+++ b/platform/android/lynxtextra/src/main/java/com/lynx/textra/JavaCanvasHelper.java
@@ -141,8 +141,8 @@ public class JavaCanvasHelper {
   }
 
   protected void translate(BBufferInputStream stream) throws IOException {
-    float x = TTTextUtils.Dp2Px(stream.readFloat());
-    float y = TTTextUtils.Dp2Px(stream.readFloat());
+    float x = stream.readFloat();
+    float y = stream.readFloat();
     canvas_.translate(x, y);
   }
 
@@ -158,33 +158,33 @@ public class JavaCanvasHelper {
   }
 
   protected void skew(BBufferInputStream stream) throws IOException {
-    float x = TTTextUtils.Dp2Px(stream.readFloat());
-    float y = TTTextUtils.Dp2Px(stream.readFloat());
+    float x = stream.readFloat();
+    float y = stream.readFloat();
     canvas_.skew(x, y);
   }
 
   protected void clipRect(BBufferInputStream stream) throws IOException {
-    float l = TTTextUtils.Dp2Px(stream.readFloat());
-    float t = TTTextUtils.Dp2Px(stream.readFloat());
-    float r = TTTextUtils.Dp2Px(stream.readFloat());
-    float b = TTTextUtils.Dp2Px(stream.readFloat());
+    float l = stream.readFloat();
+    float t = stream.readFloat();
+    float r = stream.readFloat();
+    float b = stream.readFloat();
     canvas_.clipRect(l, t, r, b);
   }
 
   protected void clearRect(BBufferInputStream stream) throws IOException {
-    float l = TTTextUtils.Dp2Px(stream.readFloat());
-    float t = TTTextUtils.Dp2Px(stream.readFloat());
-    float r = TTTextUtils.Dp2Px(stream.readFloat());
-    float b = TTTextUtils.Dp2Px(stream.readFloat());
+    float l = stream.readFloat();
+    float t = stream.readFloat();
+    float r = stream.readFloat();
+    float b = stream.readFloat();
     // TODO: ClearRect
   }
 
   protected void fillRect(BBufferInputStream stream) throws IOException {
     int color = stream.readInt();
-    float l = TTTextUtils.Dp2Px(stream.readFloat());
-    float t = TTTextUtils.Dp2Px(stream.readFloat());
-    float r = TTTextUtils.Dp2Px(stream.readFloat());
-    float b = TTTextUtils.Dp2Px(stream.readFloat());
+    float l = stream.readFloat();
+    float t = stream.readFloat();
+    float r = stream.readFloat();
+    float b = stream.readFloat();
     Paint p = new Paint();
     p.setColor(color);
     p.setStyle(Paint.Style.FILL);
@@ -197,10 +197,10 @@ public class JavaCanvasHelper {
   }
 
   protected void drawLine(BBufferInputStream stream) throws IOException {
-    float x1 = TTTextUtils.Dp2Px(stream.readFloat());
-    float y1 = TTTextUtils.Dp2Px(stream.readFloat());
-    float x2 = TTTextUtils.Dp2Px(stream.readFloat());
-    float y2 = TTTextUtils.Dp2Px(stream.readFloat());
+    float x1 = stream.readFloat();
+    float y1 = stream.readFloat();
+    float x2 = stream.readFloat();
+    float y2 = stream.readFloat();
     Paint p = ReadPaint(stream, paint_);
     p.setColor(color_);
     if (color_ != 0 && stroke_color_ == color_) {
@@ -220,10 +220,10 @@ public class JavaCanvasHelper {
   }
 
   protected void drawRect(BBufferInputStream stream) throws IOException {
-    float l = TTTextUtils.Dp2Px(stream.readFloat());
-    float t = TTTextUtils.Dp2Px(stream.readFloat());
-    float r = TTTextUtils.Dp2Px(stream.readFloat());
-    float b = TTTextUtils.Dp2Px(stream.readFloat());
+    float l = stream.readFloat();
+    float t = stream.readFloat();
+    float r = stream.readFloat();
+    float b = stream.readFloat();
     Paint p = ReadPaint(stream, paint_);
     p.setColor(color_);
     if (color_ != 0 && stroke_color_ == color_) {
@@ -243,11 +243,11 @@ public class JavaCanvasHelper {
   }
 
   protected void drawRoundRect(BBufferInputStream stream) throws IOException {
-    float l = TTTextUtils.Dp2Px(stream.readFloat());
-    float t = TTTextUtils.Dp2Px(stream.readFloat());
-    float r = TTTextUtils.Dp2Px(stream.readFloat());
-    float b = TTTextUtils.Dp2Px(stream.readFloat());
-    float radii = TTTextUtils.Dp2Px(stream.readFloat());
+    float l = stream.readFloat();
+    float t = stream.readFloat();
+    float r = stream.readFloat();
+    float b = stream.readFloat();
+    float radii = stream.readFloat();
     Paint p = ReadPaint(stream, paint_);
     p.setColor(color_);
     if (color_ != 0 && stroke_color_ == color_) {
@@ -279,18 +279,18 @@ public class JavaCanvasHelper {
   }
 
   protected void drawOval(BBufferInputStream stream) throws IOException {
-    float l = TTTextUtils.Dp2Px(stream.readFloat());
-    float t = TTTextUtils.Dp2Px(stream.readFloat());
-    float r = TTTextUtils.Dp2Px(stream.readFloat());
-    float b = TTTextUtils.Dp2Px(stream.readFloat());
+    float l = stream.readFloat();
+    float t = stream.readFloat();
+    float r = stream.readFloat();
+    float b = stream.readFloat();
     Paint p = ReadPaint(stream, paint_);
     //        canvas_.drawOval(l, t, r, b, p);
   }
 
   protected void drawCircle(BBufferInputStream stream) throws IOException {
-    float x = TTTextUtils.Dp2Px(stream.readFloat());
-    float y = TTTextUtils.Dp2Px(stream.readFloat());
-    float r = TTTextUtils.Dp2Px(stream.readFloat());
+    float x = stream.readFloat();
+    float y = stream.readFloat();
+    float r = stream.readFloat();
     Paint p = ReadPaint(stream, paint_);
     p.setColor(color_);
     if (color_ != 0 && stroke_color_ == color_) {
@@ -310,12 +310,12 @@ public class JavaCanvasHelper {
   }
 
   protected void drawArc(BBufferInputStream stream) throws IOException {
-    float l = TTTextUtils.Dp2Px(stream.readFloat());
-    float t = TTTextUtils.Dp2Px(stream.readFloat());
-    float r = TTTextUtils.Dp2Px(stream.readFloat());
-    float b = TTTextUtils.Dp2Px(stream.readFloat());
-    float start = TTTextUtils.Dp2Px(stream.readFloat());
-    float end = TTTextUtils.Dp2Px(stream.readFloat());
+    float l = stream.readFloat();
+    float t = stream.readFloat();
+    float r = stream.readFloat();
+    float b = stream.readFloat();
+    float start = stream.readFloat();
+    float end = stream.readFloat();
     boolean center = stream.readInt() != 0;
     Paint p = ReadPaint(stream, paint_);
   }
@@ -343,13 +343,13 @@ public class JavaCanvasHelper {
   }
 
   protected void drawArcTo(BBufferInputStream stream) throws IOException {
-    float x1 = TTTextUtils.Dp2Px(stream.readFloat());
-    float y1 = TTTextUtils.Dp2Px(stream.readFloat());
-    float x2 = TTTextUtils.Dp2Px(stream.readFloat());
-    float y2 = TTTextUtils.Dp2Px(stream.readFloat());
-    float x3 = TTTextUtils.Dp2Px(stream.readFloat());
-    float y3 = TTTextUtils.Dp2Px(stream.readFloat());
-    float r = TTTextUtils.Dp2Px(stream.readFloat());
+    float x1 = stream.readFloat();
+    float y1 = stream.readFloat();
+    float x2 = stream.readFloat();
+    float y2 = stream.readFloat();
+    float x3 = stream.readFloat();
+    float y3 = stream.readFloat();
+    float r = stream.readFloat();
     Paint p = ReadPaint(stream, paint_);
   }
 
@@ -363,8 +363,8 @@ public class JavaCanvasHelper {
     }
     while (char_count > 0 && text_[char_count - 1] < 32) char_count--;
 
-    float x = TTTextUtils.Dp2Px(stream.readFloat());
-    float y = TTTextUtils.Dp2Px(stream.readFloat());
+    float x = stream.readFloat();
+    float y = stream.readFloat();
     paint_.setTypeface(ttfont.mTypeface);
     Paint p = ReadPaint(stream, paint_);
     p.setFakeBoldText(is_bold_);
@@ -388,8 +388,8 @@ public class JavaCanvasHelper {
 
   protected void drawGlyphs(BBufferInputStream stream) throws IOException {
     JavaTypeface ttfont = mFontManager.GetTypefaceByIndex(stream.readInt());
-    float x = TTTextUtils.Dp2Px(stream.readFloat());
-    float y = TTTextUtils.Dp2Px(stream.readFloat());
+    float x = stream.readFloat();
+    float y = stream.readFloat();
     int glyph_count = stream.readInt();
     int[] glyph_ids = new int[glyph_count];
     float[] pos = new float[2 * glyph_count];
@@ -402,10 +402,10 @@ public class JavaCanvasHelper {
 
   protected void drawRunDelegate(BBufferInputStream stream) throws IOException {
     int id = stream.readInt();
-    float dl = TTTextUtils.Dp2Px(stream.readFloat());
-    float dt = TTTextUtils.Dp2Px(stream.readFloat());
-    float dr = TTTextUtils.Dp2Px(stream.readFloat());
-    float db = TTTextUtils.Dp2Px(stream.readFloat());
+    float dl = stream.readFloat();
+    float dt = stream.readFloat();
+    float dr = stream.readFloat();
+    float db = stream.readFloat();
     Paint p = ReadPaint(stream, paint_);
   }
 
@@ -418,10 +418,10 @@ public class JavaCanvasHelper {
     int len = stream.readInt();
     byte[] buffer = new byte[len];
     stream.read(buffer, 0, len);
-    float dl = TTTextUtils.Dp2Px(stream.readFloat());
-    float dt = TTTextUtils.Dp2Px(stream.readFloat());
-    float dr = TTTextUtils.Dp2Px(stream.readFloat());
-    float db = TTTextUtils.Dp2Px(stream.readFloat());
+    float dl = stream.readFloat();
+    float dt = stream.readFloat();
+    float dr = stream.readFloat();
+    float db = stream.readFloat();
     Paint p = ReadPaint(stream, paint_);
     Bitmap img = BitmapFactory.decodeByteArray(buffer, 0, len);
     canvas_.drawBitmap(img, new Rect(0, 0, img.getWidth(), img.getHeight()),
@@ -432,14 +432,14 @@ public class JavaCanvasHelper {
     int len = stream.readInt();
     byte[] buffer = new byte[len];
     stream.read(buffer, 0, len);
-    float sl = TTTextUtils.Dp2Px(stream.readFloat());
-    float st = TTTextUtils.Dp2Px(stream.readFloat());
-    float sr = TTTextUtils.Dp2Px(stream.readFloat());
-    float sb = TTTextUtils.Dp2Px(stream.readFloat());
-    float dl = TTTextUtils.Dp2Px(stream.readFloat());
-    float dt = TTTextUtils.Dp2Px(stream.readFloat());
-    float dr = TTTextUtils.Dp2Px(stream.readFloat());
-    float db = TTTextUtils.Dp2Px(stream.readFloat());
+    float sl = stream.readFloat();
+    float st = stream.readFloat();
+    float sr = stream.readFloat();
+    float sb = stream.readFloat();
+    float dl = stream.readFloat();
+    float dt = stream.readFloat();
+    float dr = stream.readFloat();
+    float db = stream.readFloat();
     Paint p = ReadPaint(stream, paint_);
     Bitmap img = BitmapFactory.decodeByteArray(buffer, 0, len);
     canvas_.drawBitmap(img, new Rect((int) sl, (int) st, (int) sr, (int) sb),
@@ -448,10 +448,10 @@ public class JavaCanvasHelper {
 
   protected Paint ReadPaint(BBufferInputStream stream, Paint painter) throws IOException {
     painter.setAntiAlias(true);
-    painter.setStrokeWidth(TTTextUtils.Dp2Px(stream.readFloat()));
+    painter.setStrokeWidth(stream.readFloat());
     color_ = stream.readInt();
     stroke_color_ = stream.readInt();
-    text_size_ = TTTextUtils.Dp2Px(stream.readFloat());
+    text_size_ = stream.readFloat();
     painter.setTextSize(text_size_);
     text_skew_ = stream.readFloat();
     int flag = stream.readByte();
@@ -479,27 +479,27 @@ public class JavaCanvasHelper {
       case kLines: {
         int len = stream.readInt();
         for (int i = 0; i < len; i++) {
-          float x = TTTextUtils.Dp2Px(stream.readFloat());
-          float y = TTTextUtils.Dp2Px(stream.readFloat());
+          float x = stream.readFloat();
+          float y = stream.readFloat();
           path.lineTo(x, y);
         }
       } break;
       case kArc: {
-        float x1 = TTTextUtils.Dp2Px(stream.readFloat());
-        float y1 = TTTextUtils.Dp2Px(stream.readFloat());
-        float x2 = TTTextUtils.Dp2Px(stream.readFloat());
-        float y2 = TTTextUtils.Dp2Px(stream.readFloat());
-        float x3 = TTTextUtils.Dp2Px(stream.readFloat());
-        float y3 = TTTextUtils.Dp2Px(stream.readFloat());
-        float r = TTTextUtils.Dp2Px(stream.readFloat());
+        float x1 = stream.readFloat();
+        float y1 = stream.readFloat();
+        float x2 = stream.readFloat();
+        float y2 = stream.readFloat();
+        float x3 = stream.readFloat();
+        float y3 = stream.readFloat();
+        float r = stream.readFloat();
         // TODO:add arc
       } break;
       case kBezier: {
         int len = stream.readInt();
         PointF[] points = new PointF[len];
         for (int i = 0; i < len; i++) {
-          float x = TTTextUtils.Dp2Px(stream.readFloat());
-          float y = TTTextUtils.Dp2Px(stream.readFloat());
+          float x = stream.readFloat();
+          float y = stream.readFloat();
           points[i] = new PointF(x, y);
         }
         if (len == 2) {
@@ -510,8 +510,8 @@ public class JavaCanvasHelper {
         }
       } break;
       case kMoveTo: {
-        float x = TTTextUtils.Dp2Px(stream.readFloat());
-        float y = TTTextUtils.Dp2Px(stream.readFloat());
+        float x = stream.readFloat();
+        float y = stream.readFloat();
         path.moveTo(x, y);
       } break;
       case kMultiPath: {

--- a/platform/android/lynxtextra/src/main/java/com/lynx/textra/JavaFontManager.java
+++ b/platform/android/lynxtextra/src/main/java/com/lynx/textra/JavaFontManager.java
@@ -7,15 +7,16 @@ package com.lynx.textra;
 import android.graphics.Typeface;
 import android.graphics.fonts.Font;
 import java.lang.reflect.Type;
-import java.util.LinkedHashMap;
-import java.util.LinkedList;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class JavaFontManager {
   private final long mNativeHandler;
-  private final AtomicInteger mCount = new AtomicInteger(0);
-  private final LinkedHashMap<JavaTypeface.FontKey, JavaTypeface> mFontMap = new LinkedHashMap<>();
-  private final LinkedList<JavaTypeface> mFontList = new LinkedList<>();
+  private final ConcurrentHashMap<JavaTypeface.FontKey, JavaTypeface> mFontMap =
+      new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<Integer, JavaTypeface> mTypefaceByIndex =
+      new ConcurrentHashMap<>();
+  private final AtomicInteger mCount = new AtomicInteger();
 
   public JavaFontManager(long handler) {
     mNativeHandler = handler;
@@ -25,45 +26,54 @@ public class JavaFontManager {
     return mNativeHandler;
   }
 
-  public synchronized JavaTypeface CreateOrRegisterTypeface(
+  public JavaTypeface CreateOrRegisterTypeface(
       Typeface typeface, String families, int font_weight, boolean italic) {
-    JavaTypeface.FontKey key = new JavaTypeface.FontKey();
-    if (families != null && !families.isEmpty()) {
-      key.mFontFamily = families;
-    }
-    key.mFontWeight = font_weight;
-    key.mItalic = italic;
+    JavaTypeface.FontKey key = CreateFontKey(families, font_weight, italic);
     JavaTypeface cached_typeface = mFontMap.get(key);
-    if (cached_typeface == null) {
-      cached_typeface = RegisterTypeface(typeface, key, CreateNativeTypeface(mNativeHandler));
-    } else if (cached_typeface.mTypeface != typeface) {
-      mFontList.add(cached_typeface);
-      cached_typeface = RegisterTypeface(typeface, key, CreateNativeTypeface(mNativeHandler));
+    if (cached_typeface != null && cached_typeface.mTypeface == typeface) {
+      return cached_typeface;
     }
-    mFontMap.put(key, cached_typeface);
-    return cached_typeface;
+
+    JavaTypeface candidate = RegisterTypeface(typeface, key, CreateNativeTypeface(mNativeHandler));
+    mTypefaceByIndex.put(candidate.mIndex, candidate);
+    while (true) {
+      cached_typeface = mFontMap.get(key);
+      if (cached_typeface != null && cached_typeface.mTypeface == typeface) {
+        mTypefaceByIndex.remove(candidate.mIndex, candidate);
+        return cached_typeface;
+      }
+      if (cached_typeface == null) {
+        if (mFontMap.putIfAbsent(key, candidate) == null) {
+          return candidate;
+        }
+      } else if (mFontMap.replace(key, cached_typeface, candidate)) {
+        return candidate;
+      }
+    }
   }
 
   public long onMatchTypefaceIndex(long index) {
     return GetTypefaceByIndex((int) index).mNativeHandler;
   }
-  public synchronized long onMatchFamilyStyle(
+  public long onMatchFamilyStyle(
       String families, int font_weight, boolean is_italic, long typeface_handler) {
-    JavaTypeface.FontKey key = new JavaTypeface.FontKey();
-    if (families != null && !families.isEmpty()) {
-      key.mFontFamily = families;
-    }
-    key.mFontWeight = font_weight;
-    key.mItalic = is_italic;
-    JavaTypeface cached_typeface = mFontMap.get(key);
+    JavaTypeface.FontKey requested_key = CreateFontKey(families, font_weight, is_italic);
+    JavaTypeface.FontKey fallback_key = requested_key;
+    JavaTypeface cached_typeface = mFontMap.get(requested_key);
     if (cached_typeface != null) {
       return cached_typeface.mNativeHandler;
     }
 
-    key.mFontFamily = "";
-    cached_typeface = mFontMap.get(key);
-    if (cached_typeface != null) {
-      return cached_typeface.mNativeHandler;
+    if (!requested_key.mFontFamily.isEmpty()) {
+      fallback_key = CreateFontKey("", font_weight, is_italic);
+      cached_typeface = mFontMap.get(fallback_key);
+      if (cached_typeface != null) {
+        JavaTypeface requested_typeface = mFontMap.get(requested_key);
+        if (requested_typeface != null) {
+          return requested_typeface.mNativeHandler;
+        }
+        return cached_typeface.mNativeHandler;
+      }
     }
 
     int style = Typeface.NORMAL;
@@ -75,59 +85,52 @@ public class JavaFontManager {
       style = Typeface.ITALIC;
     }
 
-    try {
-      Typeface tf = Typeface.create(Typeface.DEFAULT, style);
-      if (tf == null)
-        tf = Typeface.DEFAULT;
-
-      cached_typeface = RegisterTypeface(tf, key, typeface_handler);
-      if (cached_typeface.mNativeHandler == 0) {
-        cached_typeface = null;
-      }
-    } catch (Exception e) {
-      cached_typeface = null;
-    }
+    JavaTypeface candidate =
+        RegisterTypeface(Typeface.create(Typeface.DEFAULT, style), fallback_key, typeface_handler);
+    mTypefaceByIndex.put(candidate.mIndex, candidate);
+    cached_typeface = mFontMap.putIfAbsent(fallback_key, candidate);
     if (cached_typeface != null) {
-      mFontMap.put(key, cached_typeface);
-    } else {
-      if (!mFontMap.isEmpty()) {
-        cached_typeface = mFontMap.values().iterator().next();
-      } else if (!mFontList.isEmpty()) {
-        cached_typeface = mFontList.getFirst();
-      }
+      mTypefaceByIndex.remove(candidate.mIndex, candidate);
+      return cached_typeface.mNativeHandler;
     }
-
-    return cached_typeface != null ? cached_typeface.mNativeHandler : 0;
+    return candidate.mNativeHandler;
   }
 
-  private synchronized JavaTypeface RegisterTypeface(
+  private JavaTypeface RegisterTypeface(
       Typeface typeface, JavaTypeface.FontKey key, long typeface_handler) {
-    int index = mCount.incrementAndGet();
-    return new JavaTypeface(index, typeface, key, typeface_handler);
+    return new JavaTypeface(mCount.incrementAndGet(), typeface, key, typeface_handler);
   }
 
-  public synchronized JavaTypeface RegisterShapeFont(Font font, JavaTypeface.FontKey key) {
+  public JavaTypeface RegisterShapeFont(Font font, JavaTypeface.FontKey key) {
     JavaTypeface java_typeface = mFontMap.get(key);
-    if (java_typeface == null) {
-      int index = mCount.incrementAndGet();
-      java_typeface = new JavaTypeface(index, font, key, CreateNativeTypeface(mNativeHandler));
-      mFontMap.put(key, java_typeface);
+    if (java_typeface != null) {
+      return java_typeface;
     }
-    return java_typeface;
+
+    JavaTypeface candidate =
+        new JavaTypeface(mCount.incrementAndGet(), font, key, CreateNativeTypeface(mNativeHandler));
+    mTypefaceByIndex.put(candidate.mIndex, candidate);
+    java_typeface = mFontMap.putIfAbsent(key, candidate);
+    if (java_typeface != null) {
+      mTypefaceByIndex.remove(candidate.mIndex, candidate);
+      return java_typeface;
+    }
+    return candidate;
   }
 
-  public synchronized JavaTypeface GetTypefaceByIndex(int index) {
-    for (JavaTypeface java_typeface : mFontMap.values()) {
-      if (java_typeface.mIndex == index) {
-        return java_typeface;
-      }
+  public JavaTypeface GetTypefaceByIndex(int index) {
+    return mTypefaceByIndex.get(index);
+  }
+
+  private static JavaTypeface.FontKey CreateFontKey(
+      String families, int font_weight, boolean italic) {
+    JavaTypeface.FontKey key = new JavaTypeface.FontKey();
+    if (families != null && !families.isEmpty()) {
+      key.mFontFamily = families;
     }
-    for (JavaTypeface java_typeface : mFontList) {
-      if (java_typeface.mIndex == index) {
-        return java_typeface;
-      }
-    }
-    return null;
+    key.mFontWeight = font_weight;
+    key.mItalic = italic;
+    return key;
   }
 
   private native void BindNativeInstance(long nativeHandler, JavaFontManager java_instance);

--- a/platform/android/lynxtextra/src/main/java/com/lynx/textra/JavaShaper.java
+++ b/platform/android/lynxtextra/src/main/java/com/lynx/textra/JavaShaper.java
@@ -5,25 +5,20 @@
 package com.lynx.textra;
 
 import android.graphics.Paint;
-import java.util.HashMap;
 
 public class JavaShaper {
-  private HashMap<Integer, JavaTypeface> mFontMap = new HashMap<>(10);
+  private static final int INITIAL_ADVANCES_CAPACITY = 32;
+  private static final int MAX_REUSABLE_ADVANCES_CAPACITY = 256;
 
-  public JavaShaper(JavaFontManager font_manager) {
-    mFontManager = font_manager;
-  }
+  public JavaShaper(JavaFontManager font_manager) {}
 
   public float[] OnShapeText(
       String content, JavaTypeface font, float text_size, boolean is_rtl, boolean italic) {
-    float[] result = new float[content.length()];
+    int textLength = content.length();
+    float[] result = obtainAdvances(textLength);
     mPaint.setTypeface(font.mTypeface);
-    mPaint.setTextSize(TTTextUtils.Dp2Px(text_size));
+    mPaint.setTextSize(text_size);
     mPaint.getTextWidths(content, result);
-    for (int k = 0; k < content.length(); k++) {
-      result[k] = TTTextUtils.Px2Dp(result[k]);
-    }
-    font.GetFontMetrics(text_size);
     return result;
   }
 
@@ -32,7 +27,18 @@ public class JavaShaper {
     return null;
   }
 
-  private JavaFontManager mFontManager = null;
-  private BBufferOutputStream bs = null;
-  private Paint mPaint = new Paint();
+  private float[] obtainAdvances(int requiredCapacity) {
+    if (requiredCapacity > MAX_REUSABLE_ADVANCES_CAPACITY) {
+      return new float[requiredCapacity];
+    }
+    if (requiredCapacity > mAdvances.length) {
+      int newCapacity = Math.min(
+          MAX_REUSABLE_ADVANCES_CAPACITY, Math.max(requiredCapacity, mAdvances.length * 2));
+      mAdvances = new float[newCapacity];
+    }
+    return mAdvances;
+  }
+
+  private final Paint mPaint = new Paint();
+  private float[] mAdvances = new float[INITIAL_ADVANCES_CAPACITY];
 }

--- a/platform/android/lynxtextra/src/main/java/com/lynx/textra/JavaTypeface.java
+++ b/platform/android/lynxtextra/src/main/java/com/lynx/textra/JavaTypeface.java
@@ -11,6 +11,13 @@ import android.graphics.fonts.Font;
 import java.util.Objects;
 
 public class JavaTypeface {
+  private static final ThreadLocal<Paint> sPainter = new ThreadLocal<Paint>() {
+    @Override
+    protected Paint initialValue() {
+      return new Paint();
+    }
+  };
+
   public static class FontKey {
     String mFontFamily = "";
     int mFontWeight = 400;
@@ -27,7 +34,9 @@ public class JavaTypeface {
 
     @Override
     public int hashCode() {
-      return Objects.hash(mFontFamily, mFontWeight, mItalic);
+      int result = mFontFamily.hashCode();
+      result = 31 * result + mFontWeight;
+      return 31 * result + (mItalic ? 1 : 0);
     }
   }
 
@@ -41,15 +50,14 @@ public class JavaTypeface {
 
   public long mNativeHandler = 0;
 
-  private float dpi = 1;
-
   public JavaTypeface(int index, Typeface typeface, FontKey fontKey, long nativeHandler) {
     mIndex = index;
     mTypeface = typeface;
     mFontKey = fontKey;
     mNativeHandler = nativeHandler;
-    GetFontMetrics(24);
-    BindNativeHandler(nativeHandler, this, mIndex);
+    InitFontMetrics(24);
+    BindNativeHandler(nativeHandler, this, mIndex, mFontMetrics.ascent / mTextSize,
+        mFontMetrics.descent / mTextSize);
   }
 
   public JavaTypeface(int index, Font typeface, FontKey fontKey, long nativeHandler) {
@@ -57,7 +65,9 @@ public class JavaTypeface {
     mFont = typeface;
     mFontKey = fontKey;
     mNativeHandler = nativeHandler;
-    BindNativeHandler(nativeHandler, this, mIndex);
+    InitFontMetrics(24);
+    BindNativeHandler(nativeHandler, this, mIndex, mFontMetrics.ascent / mTextSize,
+        mFontMetrics.descent / mTextSize);
   }
 
   @Override
@@ -75,26 +85,21 @@ public class JavaTypeface {
     return Objects.hash(mFontKey);
   }
 
-  public float[] GetFontMetrics(float text_size) {
-    float[] font_metrics = new float[2];
-    if (mTextSize == 0 || dpi != TTTextUtils.density_) {
-      TTText.mPainter.setTypeface(mTypeface);
-      TTText.mPainter.setTextSize(TTTextUtils.Dp2Px(text_size));
-      TTText.mPainter.getFontMetrics(mFontMetrics);
-      dpi = TTTextUtils.density_;
-    } else {
-      float scale = text_size / mTextSize;
-      mFontMetrics.ascent *= scale;
-      mFontMetrics.descent *= scale;
-    }
+  private void InitFontMetrics(float text_size) {
+    Paint paint = sPainter.get();
+    paint.setTypeface(mTypeface);
+    paint.setTextSize(text_size);
+    paint.getFontMetrics(mFontMetrics);
     mTextSize = text_size;
-    font_metrics[0] = TTTextUtils.Px2Dp(mFontMetrics.ascent);
-    font_metrics[1] = TTTextUtils.Px2Dp(mFontMetrics.descent);
-    return font_metrics;
+  }
+
+  public float[] GetFontMetrics(float text_size) {
+    float scale = text_size / mTextSize;
+    return new float[] {mFontMetrics.ascent * scale, mFontMetrics.descent * scale};
   }
 
   public float[] GetTextBounds(char[] text, float text_size) {
-    Paint paint = TTText.mPainter;
+    Paint paint = sPainter.get();
     Rect rect = new Rect();
     paint.setTypeface(mTypeface);
     paint.setTextSize(text_size);
@@ -107,5 +112,6 @@ public class JavaTypeface {
     return ret;
   }
 
-  public native void BindNativeHandler(long nativeHandler, JavaTypeface javaTypeface, int index);
+  public native void BindNativeHandler(
+      long nativeHandler, JavaTypeface javaTypeface, int index, float ascent, float descent);
 }

--- a/platform/android/lynxtextra/src/main/java/com/lynx/textra/TTText.java
+++ b/platform/android/lynxtextra/src/main/java/com/lynx/textra/TTText.java
@@ -4,8 +4,6 @@
 
 package com.lynx.textra;
 
-import android.graphics.Paint;
-
 public class TTText {
   private static boolean sInitialized = false;
   private static boolean sSelfRenderingPreloaded = false;
@@ -47,6 +45,5 @@ public class TTText {
 
   private native static JavaFontManager nativeGetDefaultFontManager();
 
-  public static Paint mPainter = new Paint();
   public static JavaFontManager mFontManager = null;
 }

--- a/public/textra/platform/java/java_font_manager.h
+++ b/public/textra/platform/java/java_font_manager.h
@@ -47,6 +47,7 @@ class L_EXPORT JavaFontManager : public IFontManager {
  private:
   std::unique_ptr<ScopedGlobalRef> java_instance_ = nullptr;
   std::list<std::shared_ptr<JavaTypeface>> typeface_list_;
+  std::mutex typeface_list_mutex_;
   std::unordered_map<FontDescriptor, std::shared_ptr<JavaTypeface>,
                      FontDescriptor::Hasher>
       typeface_map_;

--- a/public/textra/platform/java/java_typeface.h
+++ b/public/textra/platform/java/java_typeface.h
@@ -19,7 +19,8 @@ class JavaTypeface final : public ITypefaceHelper {
   ~JavaTypeface() override;
 
  public:
-  void BindJavaHandler(jobject handler, uint32_t unique_id);
+  void BindJavaHandler(JNIEnv* env, jobject handler, uint32_t unique_id,
+                       float font_ascent_ratio, float font_descent_ratio);
 
  public:
   jobject GetInstance() const;
@@ -44,6 +45,8 @@ class JavaTypeface final : public ITypefaceHelper {
 
  private:
   std::unique_ptr<ScopedGlobalRef> java_instance_ = nullptr;
+  float font_ascent_ratio_ = 0;
+  float font_descent_ratio_ = 0;
 };
 }  // namespace tttext
 }  // namespace ttoffice

--- a/public/textra/platform/java/tttext_jni_proxy.h
+++ b/public/textra/platform/java/tttext_jni_proxy.h
@@ -59,7 +59,6 @@ class TTTextJNIProxy {
   static jmethodID JavaFontManager_method_init_;
   static jmethodID JavaFontManager_method_onMatchFamilyStyle_;
   static jmethodID JavaFontManager_method_onMatchTypefaceIndex_;
-  static jmethodID JavaTypeface_method_GetFontMetrics;
   static jmethodID JavaTypeface_method_GetTextBounds;
   static std::unique_ptr<ScopedGlobalRef> tttext_utils_class_;
   static jmethodID TTTextUtils_method_SystemFontStyleAdjust_;

--- a/src/ports/shaper/java/java_font_manager.cc
+++ b/src/ports/shaper/java/java_font_manager.cc
@@ -70,9 +70,12 @@ void* JavaFontManager::getPlatformFontFromTypeface(TypefaceRef typeface) {
 }
 
 std::shared_ptr<JavaTypeface> JavaFontManager::CreateNativeTypeface() {
-  typeface_list_.push_back(std::make_shared<JavaTypeface>(0));
-  return typeface_list_.back();
+  auto typeface = std::make_shared<JavaTypeface>(0);
+  std::lock_guard<std::mutex> lock(typeface_list_mutex_);
+  typeface_list_.push_back(typeface);
+  return typeface;
 }
+
 std::shared_ptr<JavaTypeface> JavaFontManager::matchTypeface(
     const FontDescriptor& fd) {
   {

--- a/src/ports/shaper/java/java_shaper.cc
+++ b/src/ports/shaper/java/java_shaper.cc
@@ -84,21 +84,20 @@ void JavaShaper::OnShapeText(const ShapeKey& key, ShapeResult* result) const {
   if (info_list == nullptr) {
     // maybe encounter java exception
     ClearException(env);
-    std::vector<float> advances(glyph_count, 0);
-    reader.advances_.insert(reader.advances_.begin(), advances.begin(),
-                            advances.end());
+    reader.advances_.resize(glyph_count, 0);
     reader.font_ = java_typeface;
     result->AppendPlatformShapingResult(reader);
+    env->DeleteLocalRef(j_content);
     return;
   }
   auto* ret_advances = env->GetFloatArrayElements(info_list, nullptr);
-  size_t ret_length = env->GetArrayLength(info_list);
-  TTASSERT(ret_length == glyph_count);
+  auto ret_length = env->GetArrayLength(info_list);
+  TTASSERT(ret_length >= static_cast<jsize>(glyph_count));
   reader.advances_.insert(reader.advances_.begin(), ret_advances,
                           ret_advances + glyph_count);
   reader.font_ = java_typeface;
   result->AppendPlatformShapingResult(reader);
-  env->ReleaseFloatArrayElements(info_list, ret_advances, 0);
+  env->ReleaseFloatArrayElements(info_list, ret_advances, JNI_ABORT);
   env->DeleteLocalRef(info_list);
   env->DeleteLocalRef(j_content);
 }

--- a/src/ports/shaper/java/java_typeface.cc
+++ b/src/ports/shaper/java/java_typeface.cc
@@ -11,10 +11,13 @@ namespace tttext {
 JavaTypeface::JavaTypeface(uint32_t unique_id) : ITypefaceHelper(unique_id) {}
 JavaTypeface::~JavaTypeface() = default;
 jobject JavaTypeface::GetInstance() const { return java_instance_->get(); }
-void JavaTypeface::BindJavaHandler(jobject handler, uint32_t unique_id) {
-  auto env = TTTextJNIProxy::GetInstance().GetCurrentJNIEnv();
+void JavaTypeface::BindJavaHandler(JNIEnv* env, jobject handler,
+                                   uint32_t unique_id, float font_ascent_ratio,
+                                   float font_descent_ratio) {
   java_instance_ = std::make_unique<ScopedGlobalRef>(env, handler);
   unique_id_ = unique_id;
+  font_ascent_ratio_ = font_ascent_ratio;
+  font_descent_ratio_ = font_descent_ratio;
 }
 float JavaTypeface::GetHorizontalAdvance(GlyphID glyph_id,
                                          float font_size) const {
@@ -57,22 +60,8 @@ uint16_t JavaTypeface::UnicharToGlyph(Unichar codepoint,
 void JavaTypeface::UnicharsToGlyphs(const Unichar* unichars, uint32_t count,
                                     GlyphID* glyphs) const {}
 void JavaTypeface::OnCreateFontInfo(FontInfo* info, float font_size) const {
-  auto& proxy = TTTextJNIProxy::GetInstance();
-  auto env = proxy.GetCurrentJNIEnv();
-  auto* metrics = (jfloatArray)env->CallObjectMethod(
-      java_instance_->get(), proxy.JavaTypeface_method_GetFontMetrics,
-      font_size);
-  if (metrics == nullptr) {
-    ClearException(env);
-    info->SetAscent(0);
-    info->SetDescent(0);
-    info->SetFontSize(font_size);
-    return;
-  }
-  auto* jarray = env->GetFloatArrayElements(metrics, nullptr);
-  TTASSERT(env->GetArrayLength(metrics) == 2);
-  info->SetAscent(jarray[0]);
-  info->SetDescent(jarray[1]);
+  info->SetAscent(font_ascent_ratio_ * font_size);
+  info->SetDescent(font_descent_ratio_ * font_size);
   info->SetFontSize(font_size);
 }
 }  // namespace tttext

--- a/src/ports/shaper/java/tttext_jni_proxy.cc
+++ b/src/ports/shaper/java/tttext_jni_proxy.cc
@@ -38,7 +38,6 @@ jmethodID TTTextJNIProxy::JavaFontManager_method_init_ = nullptr;
 jmethodID TTTextJNIProxy::JavaFontManager_method_onMatchFamilyStyle_ = nullptr;
 jmethodID TTTextJNIProxy::JavaFontManager_method_onMatchTypefaceIndex_ =
     nullptr;
-jmethodID TTTextJNIProxy::JavaTypeface_method_GetFontMetrics = nullptr;
 jmethodID TTTextJNIProxy::JavaTypeface_method_GetTextBounds = nullptr;
 
 std::unique_ptr<ScopedGlobalRef> TTTextJNIProxy::tttext_utils_class_ = nullptr;
@@ -147,8 +146,6 @@ void TTTextJNIProxy::InitialJNI(JNIEnv* env) {
       env, clzz_font_manager, INSTANCE_METHOD, "onMatchTypefaceIndex", "(J)J");
   env->DeleteLocalRef(clzz_font_manager);
   auto clzz_JavaTypeface = GetClass(env, CLASS_JAVA_TYPEFACE);
-  JavaTypeface_method_GetFontMetrics = GetMethod(
-      env, clzz_JavaTypeface, INSTANCE_METHOD, "GetFontMetrics", "(F)[F");
   JavaTypeface_method_GetTextBounds = GetMethod(
       env, clzz_JavaTypeface, INSTANCE_METHOD, "GetTextBounds", "([CF)[F");
   env->DeleteLocalRef(clzz_JavaTypeface);
@@ -238,11 +235,12 @@ void WarmICU() {
       &out_buffer_32, &out_buffer_32);
 }
 
-extern "C" JNIEXPORT void JNICALL
-JavaTypefaceBindNativeInstance(JNIEnv* env, jobject thiz, jlong native_handler,
-                               jobject java_instance, jint index) {
+extern "C" JNIEXPORT void JNICALL JavaTypefaceBindNativeInstance(
+    JNIEnv* env, jobject thiz, jlong native_handler, jobject java_instance,
+    jint index, jfloat font_ascent_ratio, jfloat font_descent_ratio) {
   auto typeface = reinterpret_cast<tttext::JavaTypeface*>(native_handler);
-  typeface->BindJavaHandler(java_instance, index);
+  typeface->BindJavaHandler(env, java_instance, index, font_ascent_ratio,
+                            font_descent_ratio);
 }
 
 extern "C" JNIEXPORT void JNICALL JavaFontManagerBindNativeInstance(
@@ -261,7 +259,7 @@ extern "C" JNIEXPORT jlong JNICALL JavaFontManagerCreateNativeTypeface(
 
 // define the methods to be registered
 static JNINativeMethod java_typeface_methods[] = {
-    {"BindNativeHandler", "(JLcom/lynx/textra/JavaTypeface;I)V",
+    {"BindNativeHandler", "(JLcom/lynx/textra/JavaTypeface;IFF)V",
      reinterpret_cast<void*>(JavaTypefaceBindNativeInstance)},
 };
 

--- a/src/textlayout/paragraph_impl.cc
+++ b/src/textlayout/paragraph_impl.cc
@@ -148,9 +148,9 @@ void ParagraphImpl::FormatRunList() {
     FormatIndent();
     if (content_.Empty() && run_lst_.empty()) {
       AddTextRun(nullptr, "\n", 1);
+      u32_content = content_.ToUTF32();
     }
     TTASSERT(!content_.Empty() || !run_lst_.empty());
-    auto u32_content = content_.ToUTF32();
     boundary_analyst_ = std::make_unique<BoundaryAnalyst>(
         u32_content.data(), u32_content.length(),
         paragraph_style_.line_break_strategy_);

--- a/src/textlayout/utils/icu_wrapper.cc
+++ b/src/textlayout/utils/icu_wrapper.cc
@@ -485,6 +485,15 @@ void ICUWrapper::BidiInit(const char32_t* u32_content, const uint32_t& length,
   if (ErrorCode != U_ZERO_ERROR) {
     return DefaultBidiResult(length, bidi_levels, visual_map, logical_map);
   }
+  if (ICUWrapper::ubidiGetDirection(para) == UBIDI_LTR) {
+    for (auto index = 0u; index < length; index++) {
+      bidi_levels[index] = 0;
+      visual_map[index] = index;
+      logical_map[index] = index;
+    }
+    bidi_close(para);
+    return;
+  }
   const auto* bidiLevels = bidi_getLevels(para, pErrorCode);
   if (ErrorCode != U_ZERO_ERROR) {
     return DefaultBidiResult(length, bidi_levels, visual_map, logical_map);


### PR DESCRIPTION
- Use concurrent font caches with non-blocking lookup paths and serialize only font registration.
- Add constant-time typeface index lookup and allocation-free font key hashing.
- Reuse shaping advance arrays and correctly release JNI array resources.
- Use pixel units directly inside Android shaping, font metrics, and canvas rendering.
- Preserve existing public density conversion APIs while removing internal dependencies on global density.