### PR TITLE
Add exact-text-height line box rule

### DIFF
--- a/public/textra/layout_definition.h
+++ b/public/textra/layout_definition.h
@@ -113,6 +113,10 @@ enum class TabStopType : uint8_t {
   kNum
 };
 enum class RulerType : uint8_t { kAtLeast, kAuto, kExact };
+enum class InlineVerticalAlignmentMode : uint8_t {
+  kLegacy,
+  kLineBox,
+};
 enum class LineBreakType : uint8_t {
   kNotDefined,
   kNoBreak,

--- a/public/textra/paragraph_style.h
+++ b/public/textra/paragraph_style.h
@@ -380,6 +380,17 @@ class L_EXPORT ParagraphStyle {
   RulerType GetLineHeightRule() const;
 
   /**
+   * @brief Selects how inline vertical-align participates in line layout.
+   *
+   * kLegacy preserves TTText's existing placement behavior. kLineBox resolves
+   * super/sub and other baseline-relative values against the parent font and
+   * includes the final aligned inline box in the containing line metrics.
+   * Default is kLegacy.
+   */
+  void SetInlineVerticalAlignmentMode(InlineVerticalAlignmentMode mode);
+  InlineVerticalAlignmentMode GetInlineVerticalAlignmentMode() const;
+
+  /**
    * @brief Additional spacing before each line.
    *
    * Adds extra vertical space above each line, in addition to the

--- a/src/textlayout/layout_measurer.cc
+++ b/src/textlayout/layout_measurer.cc
@@ -163,5 +163,35 @@ float LayoutMeasurer::CalcElementY(CharacterVerticalAlignment v_align,
   }
   return y;
 }
+
+CharacterVerticalAlignment LayoutMeasurer::ResolveCharacterVerticalAlignment(
+    const BaseRun* run) {
+  if (run->GetLayoutStyle().HasStyleAttribute(Style::VerticalAlignmentFlag)) {
+    return run->GetLayoutStyle().GetVerticalAlignment();
+  }
+  return run->GetParagraph()->GetDefaultStyleImpl().GetVerticalAlignment();
+}
+
+float LayoutMeasurer::CalcInlineObjectBaselineOffset(const BaseRun* run,
+                                                     float container_ascent,
+                                                     float container_descent) {
+  const auto vertical_alignment = ResolveCharacterVerticalAlignment(run);
+  const float baseline_offset =
+      vertical_alignment == CharacterVerticalAlignment::kTop ||
+              vertical_alignment == CharacterVerticalAlignment::kBottom
+          ? 0.f
+          : run->GetParagraph()->GetBaselineOffset(run->GetStartCharPos());
+  const float font_size = run->GetLayoutStyle().GetScaledTextSize();
+  const auto metrics = run->GetScaledMetrics();
+  if (vertical_alignment == CharacterVerticalAlignment::kSuperScript) {
+    return baseline_offset + metrics.GetSupOffset(font_size);
+  }
+  if (vertical_alignment == CharacterVerticalAlignment::kSubScript) {
+    return baseline_offset + metrics.GetSubOffset(font_size);
+  }
+  return baseline_offset +
+         CalcElementY(vertical_alignment, container_ascent, container_descent,
+                      metrics.GetMaxAscent(), metrics.GetMaxDescent());
+}
 }  // namespace tttext
 }  // namespace ttoffice

--- a/src/textlayout/layout_measurer.h
+++ b/src/textlayout/layout_measurer.h
@@ -52,6 +52,11 @@ class LayoutMeasurer {
   static float CalcElementY(CharacterVerticalAlignment v_align,
                             float container_ascent, float container_descent,
                             float element_ascent, float element_descent);
+  static CharacterVerticalAlignment ResolveCharacterVerticalAlignment(
+      const BaseRun* run);
+  static float CalcInlineObjectBaselineOffset(const BaseRun* run,
+                                              float container_ascent,
+                                              float container_descent);
 };
 }  // namespace tttext
 }  // namespace ttoffice

--- a/src/textlayout/paragraph_impl.cc
+++ b/src/textlayout/paragraph_impl.cc
@@ -25,6 +25,10 @@
 
 namespace ttoffice {
 namespace tttext {
+float ParagraphImpl::GetBaselineOffset(uint32_t char_pos) const {
+  return style_manager_->GetBaselineOffset(char_pos);
+}
+
 std::unique_ptr<Paragraph> Paragraph::Create() {
   return std::make_unique<ParagraphImpl>();
 }

--- a/src/textlayout/paragraph_impl.h
+++ b/src/textlayout/paragraph_impl.h
@@ -158,6 +158,7 @@ class ParagraphImpl : public Paragraph {
   BoundaryType GetBoundaryTypeBefore(const LayoutPosition& position) const;
   BoundaryType GetBoundaryType(const LayoutPosition& position) const;
   void SetShaper(TTShaper* shaper) { shaper_ = shaper; }
+  float GetBaselineOffset(uint32_t char_pos) const;
   void ClearLayout() { formated_ = false; }
   RunDelegate* GetRunDelegateForChar(uint32_t char_index) const;
   void TransformLayoutStyleOnlyOnce();

--- a/src/textlayout/run/layout_metrics.h
+++ b/src/textlayout/run/layout_metrics.h
@@ -64,10 +64,11 @@ class LayoutMetrics {
     max_descent_ *= ratio;
     // }
   }
+  float GetSupOffset() const { return GetSupOffset(GetHeight()); }
+  float GetSupOffset(float base) const { return -0.33 * base; }
 
-  float GetSupOffset() { return -0.33 * GetHeight(); }
-
-  float GetSubOffset() { return 0.2 * GetHeight(); }
+  float GetSubOffset() const { return GetSubOffset(GetHeight()); }
+  float GetSubOffset(float base) const { return 0.2 * base; }
 
  private:
   float max_ascent_ = 0;

--- a/src/textlayout/style/paragraph_style_impl.cc
+++ b/src/textlayout/style/paragraph_style_impl.cc
@@ -31,6 +31,7 @@ ParagraphStyleImpl::ParagraphStyleImpl()
       line_height_override_(false),
       half_leading_(false),
       enable_text_bounds_(false),
+      inline_vertical_alignment_mode_(InlineVerticalAlignmentMode::kLegacy),
       overflow_wrap_(OverflowWrap::kAnywhere),
       line_break_strategy_(kLineBreakStrategyDefault) {}
 ParagraphStyleImpl::ParagraphStyleImpl(
@@ -55,6 +56,8 @@ ParagraphStyleImpl& ParagraphStyleImpl::operator=(
   line_height_override_ = paragraph_style.line_height_override_;
   half_leading_ = paragraph_style.half_leading_;
   enable_text_bounds_ = paragraph_style.enable_text_bounds_;
+  inline_vertical_alignment_mode_ =
+      paragraph_style.inline_vertical_alignment_mode_;
   overflow_wrap_ = paragraph_style.overflow_wrap_;
   line_break_strategy_ = paragraph_style.line_break_strategy_;
   return *this;
@@ -196,6 +199,14 @@ void ParagraphStyle::SetLineHeightInPercent(float percent) {
 }
 RulerType ParagraphStyle::GetLineHeightRule() const {
   return impl_->GetLineHeightRule();
+}
+void ParagraphStyle::SetInlineVerticalAlignmentMode(
+    InlineVerticalAlignmentMode mode) {
+  impl_->SetInlineVerticalAlignmentMode(mode);
+}
+InlineVerticalAlignmentMode ParagraphStyle::GetInlineVerticalAlignmentMode()
+    const {
+  return impl_->GetInlineVerticalAlignmentMode();
 }
 void ParagraphStyle::SetLineSpaceBeforePx(float px) {
   impl_->SetLineSpaceBeforePx(px);

--- a/src/textlayout/style/paragraph_style_impl.h
+++ b/src/textlayout/style/paragraph_style_impl.h
@@ -116,6 +116,12 @@ class ParagraphStyleImpl {
     spacing_->line_percent_ = percent;
   }
   RulerType GetLineHeightRule() const { return spacing_->line_rule_; }
+  void SetInlineVerticalAlignmentMode(InlineVerticalAlignmentMode mode) {
+    inline_vertical_alignment_mode_ = mode;
+  }
+  InlineVerticalAlignmentMode GetInlineVerticalAlignmentMode() const {
+    return inline_vertical_alignment_mode_;
+  }
   void SetLineSpaceBeforePx(float px) { spacing_->line_space_before_px_ = px; }
   float GetLineSpaceBeforePx() const { return spacing_->line_space_before_px_; }
   void SetLineSpaceAfterPx(float px) { spacing_->line_space_after_px_ = px; }
@@ -176,6 +182,7 @@ class ParagraphStyleImpl {
   bool line_height_override_;
   bool half_leading_;
   bool enable_text_bounds_;
+  InlineVerticalAlignmentMode inline_vertical_alignment_mode_;
   OverflowWrap overflow_wrap_;
   LineBreakStrategy line_break_strategy_;
 };

--- a/src/textlayout/text_layout_impl.cc
+++ b/src/textlayout/text_layout_impl.cc
@@ -18,6 +18,14 @@
 
 namespace ttoffice {
 namespace tttext {
+namespace {
+bool UsesExactTextLineBox(const ParagraphStyleImpl& para_style) {
+  return para_style.GetLineHeightRule() == RulerType::kExact &&
+         para_style.GetInlineVerticalAlignmentMode() ==
+             InlineVerticalAlignmentMode::kLineBox;
+}
+}  // namespace
+
 LayoutResult TextLayoutImpl::LayoutEx(Paragraph* i_para, LayoutRegion* page,
                                       TTTextContext& context,
                                       TTShaper* shaper) {
@@ -152,16 +160,19 @@ LayoutPosition TextLayoutImpl::ProcessBreakableRunList(
 }
 bool TextLayoutImpl::CheckLineNeedRelayout(LayoutRegion* region,
                                            TextLineImpl* line, float new_height,
-                                           float& next_line_top) {
+                                           float& next_line_top,
+                                           bool force_height_check) {
   next_line_top = line->line_top_;
+  const float range_height = std::max(new_height, line->range_height_floor_);
   std::vector<std::array<float, 2>> list;
   if (line->range_lst_.empty()) {
-    list = region->GetRangeList(&next_line_top, new_height,
+    list = region->GetRangeList(&next_line_top, range_height,
                                 line->GetStartIndent(), line->GetEndIndent());
     TTASSERT(!list.empty());
     line->SetRangeLst(list);
-  } else if (FloatsLarger(new_height, line->GetLineHeight())) {
-    list = region->GetRangeList(&next_line_top, new_height,
+  } else if (force_height_check ||
+             FloatsLarger(new_height, line->GetLineHeight())) {
+    list = region->GetRangeList(&next_line_top, range_height,
                                 line->GetStartIndent(), line->GetEndIndent());
     TTASSERT(!list.empty());
     if (!line->IsEqualRangeList(list)) {
@@ -212,12 +223,14 @@ LayoutPosition TextLayoutImpl::AddBreakableRunsToLine(
     if (line_break_pos > pos) {
       auto d_height = AddWordListToRunRange(range.get(), paragraph, pos,
                                             line_break_pos, &metrics);
-      if (CheckLineNeedRelayout(region, line, d_height, next_line_top)) {
+      line->UpdateLine(line_break_pos, metrics.GetMaxAscent(),
+                       metrics.GetMaxDescent(), d_height);
+      line->AdjustInlineObjectLineBox();
+      if (CheckLineNeedRelayout(region, line, line->GetLineHeight(),
+                                next_line_top, true)) {
         *result = LayoutResult::kRelayoutLine;
         return position;
       }
-      line->UpdateLine(line_break_pos, metrics.GetMaxAscent(),
-                       metrics.GetMaxDescent(), d_height);
       pos = line_break_pos;
     }
     if (line_break_pos.GetRunIdx() >= paragraph.GetRunCount() ||
@@ -264,12 +277,14 @@ LayoutPosition TextLayoutImpl::AddBreakableRunsToLine(
   if (break_pos > pos) {
     auto d_height = AddWordListToRunRange(line->GetCurrentRange(), paragraph,
                                           pos, break_pos, &metrics);
-    if (CheckLineNeedRelayout(region, line, d_height, next_line_top)) {
+    line->UpdateLine(break_pos, metrics.GetMaxAscent(), metrics.GetMaxDescent(),
+                     d_height);
+    line->AdjustInlineObjectLineBox();
+    if (CheckLineNeedRelayout(region, line, line->GetLineHeight(),
+                              next_line_top, true)) {
       *result = LayoutResult::kRelayoutLine;
       return position;
     }
-    line->UpdateLine(break_pos, metrics.GetMaxAscent(), metrics.GetMaxDescent(),
-                     d_height);
   }
   *result = LayoutResult::kBreakLine;
   return break_pos;
@@ -303,16 +318,20 @@ float TextLayoutImpl::AddWordListToRunRange(LineRange* range,
                                             const LayoutPosition& start_pos,
                                             const LayoutPosition& end_pos,
                                             LayoutMetrics* metrics) {
+  const bool use_exact_text_line_box =
+      UsesExactTextLineBox(paragraph.GetParagraphStyleImpl());
   float max_desired_height = LAYOUT_MIN_UNITS;
   for (auto pos = start_pos; pos < end_pos; pos.NextRun()) {
     auto* run = paragraph.GetRun(pos.GetRunIdx());
     auto desired_height = TryAddRun(*metrics, run);
     max_desired_height = std::fmax(max_desired_height, desired_height);
-    auto run_metrics = run->GetMetrics();
-    float baseline_offset =
-        paragraph.style_manager_->GetBaselineOffset(run->GetStartCharPos());
-    run_metrics.ApplyBaselineOffset(baseline_offset);
-    metrics->UpdateMax(run_metrics);
+    if (!(use_exact_text_line_box && run->IsObjectRun())) {
+      auto run_metrics = run->GetMetrics();
+      float baseline_offset =
+          paragraph.style_manager_->GetBaselineOffset(run->GetStartCharPos());
+      run_metrics.ApplyBaselineOffset(baseline_offset);
+      metrics->UpdateMax(run_metrics);
+    }
     auto end_char_in_run = pos.GetRunIdx() == end_pos.GetRunIdx()
                                ? end_pos.GetCharIdx()
                                : run->GetCharCount();

--- a/src/textlayout/text_layout_impl.h
+++ b/src/textlayout/text_layout_impl.h
@@ -52,7 +52,8 @@ class TextLayoutImpl {
                                                 LayoutResult* result);
 
   static bool CheckLineNeedRelayout(LayoutRegion* region, TextLineImpl* line,
-                                    float new_height, float& next_line_top);
+                                    float new_height, float& next_line_top,
+                                    bool force_height_check = false);
 
   static LayoutPosition AddBreakableRunsToLine(const ParagraphImpl& paragraph,
                                                const LayoutPosition& position,

--- a/src/textlayout/text_line_impl.cc
+++ b/src/textlayout/text_line_impl.cc
@@ -89,6 +89,80 @@ LayoutPosition TextLineImpl::UpdateLine(LayoutPosition pos, float max_ascent,
   return pos;
 }
 
+void TextLineImpl::AdjustInlineObjectLineBox() {
+  if (paragraph_->GetParagraphStyleImpl().GetInlineVerticalAlignmentMode() !=
+      InlineVerticalAlignmentMode::kLineBox) {
+    return;
+  }
+  const float baseline = GetContentBaseline();
+  float top_extension = 0.f;
+  float bottom_extension = 0.f;
+  float max_top_object_height = 0.f;
+  float max_bottom_object_height = 0.f;
+  for (const auto& range : range_lst_) {
+    for (const auto& run_range : range->run_range_lst_) {
+      const auto* run = run_range->GetRun();
+      if (!run->IsObjectRun()) {
+        continue;
+      }
+      const auto alignment =
+          LayoutMeasurer::ResolveCharacterVerticalAlignment(run);
+      const auto metrics = run->GetScaledMetrics();
+      const float object_height = metrics.GetHeight();
+      if (alignment == CharacterVerticalAlignment::kTop) {
+        max_top_object_height = std::max(max_top_object_height, object_height);
+        continue;
+      }
+      if (alignment == CharacterVerticalAlignment::kBottom) {
+        max_bottom_object_height =
+            std::max(max_bottom_object_height, object_height);
+        continue;
+      }
+      const float offset = LayoutMeasurer::CalcInlineObjectBaselineOffset(
+          run, max_ascent_, max_descent_);
+      top_extension = std::max(top_extension,
+                               -(baseline + offset + metrics.GetMaxAscent()));
+      bottom_extension = std::max(
+          bottom_extension,
+          baseline + offset + metrics.GetMaxDescent() - GetLineHeight());
+    }
+  }
+  top_extra_ += std::max(0.f, top_extension);
+  bottom_extra_ += std::max(0.f, bottom_extension);
+
+  const float line_height = GetLineHeight();
+  const float top_object_extension =
+      std::max(0.f, max_top_object_height - line_height);
+  const float bottom_object_extension =
+      std::max(0.f, max_bottom_object_height - line_height);
+  if (top_object_extension >= bottom_object_extension) {
+    bottom_extra_ += top_object_extension;
+  } else {
+    top_extra_ += bottom_object_extension;
+  }
+
+  for (const auto& range : range_lst_) {
+    for (const auto& run_range : range->run_range_lst_) {
+      const auto* run = run_range->GetRun();
+      if (!run->IsObjectRun()) {
+        continue;
+      }
+      const auto alignment =
+          LayoutMeasurer::ResolveCharacterVerticalAlignment(run);
+      const bool align_to_line =
+          alignment == CharacterVerticalAlignment::kTop ||
+          alignment == CharacterVerticalAlignment::kBottom;
+      const float line_baseline = GetContentBaseline();
+      run_range->SetYOffsetInLine(
+          line_baseline +
+          LayoutMeasurer::CalcInlineObjectBaselineOffset(
+              run, align_to_line ? line_baseline : max_ascent_,
+              align_to_line ? GetLineHeight() - line_baseline : max_descent_));
+    }
+  }
+  range_height_floor_ = std::max(range_height_floor_, GetLineHeight());
+}
+
 bool TextLineImpl::IsEqualRangeList(
     const std::vector<std::array<float, 2>>& list) const {
   if (range_lst_.size() != list.size()) return false;
@@ -138,6 +212,7 @@ void TextLineImpl::SplitToWordDrawer(const LineRange& line_range) {
         auto drawer = std::make_unique<DrawerPiece>(
             run, run_range->GetParent(), start_char - run->GetStartCharPos(),
             next_justify_opportunity - run->GetStartCharPos());
+        drawer->SetYOffsetInLine(run_range->GetYOffsetInLine());
         InsertDrawerPiece(std::move(drawer));
         start_char = next_justify_opportunity;
         next_justify_opportunity =
@@ -147,6 +222,7 @@ void TextLineImpl::SplitToWordDrawer(const LineRange& line_range) {
         auto drawer = std::make_unique<DrawerPiece>(
             run, run_range->GetParent(), start_char - run->GetStartCharPos(),
             end_char - run->GetStartCharPos());
+        drawer->SetYOffsetInLine(run_range->GetYOffsetInLine());
         InsertDrawerPiece(std::move(drawer));
       }
     }
@@ -348,45 +424,56 @@ void TextLineImpl::ApplyAlignment(ParagraphHorizontalAlignment h_align) {
       drawer->SetXOffset(start_offset);
       auto* run = drawer->GetRun();
       auto metrics = run->GetScaledMetrics();
-      auto cva = CharacterVerticalAlignment::kBaseLine;
-      if (run->GetLayoutStyle().HasStyleAttribute(
-              Style::VerticalAlignmentFlag)) {
-        cva = run->GetLayoutStyle().GetVerticalAlignment();
-      } else if (paragraph_->GetDefaultStyleImpl().HasStyleAttribute(
-                     Style::VerticalAlignmentFlag)) {
-        cva = paragraph_->GetDefaultStyleImpl().GetVerticalAlignment();
-      }
       auto y_offset = GetContentBaseline();
-      auto element_ascent = metrics.GetMaxAscent();
-      auto element_descent = metrics.GetMaxDescent();
-      if (cva == CharacterVerticalAlignment::kTextTop ||
-          cva == CharacterVerticalAlignment::kTextBottom) {
-        container_ascent = GetContentBaseline() - GetContentTop();
-        container_descent = GetContentBottom() - GetContentBaseline();
-      }
-      if (cva != CharacterVerticalAlignment::kBaseLine) {
-        y_offset += LayoutMeasurer::CalcElementY(
-            cva, container_ascent, container_descent, element_ascent,
-            element_descent);
-        if (cva == CharacterVerticalAlignment::kSuperScript) {
-          auto base_metrics = run->GetMetrics();
-          y_offset += base_metrics.GetSupOffset();
+      const bool use_line_box_vertical_alignment =
+          run->IsObjectRun() && !run->IsGhostRun() &&
+          paragraph_->GetParagraphStyleImpl()
+                  .GetInlineVerticalAlignmentMode() ==
+              InlineVerticalAlignmentMode::kLineBox;
+      if (use_line_box_vertical_alignment) {
+        y_offset = drawer->GetYOffsetInLine();
+      } else {
+        auto cva = CharacterVerticalAlignment::kBaseLine;
+        if (run->GetLayoutStyle().HasStyleAttribute(
+                Style::VerticalAlignmentFlag)) {
+          cva = run->GetLayoutStyle().GetVerticalAlignment();
+        } else if (paragraph_->GetDefaultStyleImpl().HasStyleAttribute(
+                       Style::VerticalAlignmentFlag)) {
+          cva = paragraph_->GetDefaultStyleImpl().GetVerticalAlignment();
         }
-        if (cva == CharacterVerticalAlignment::kSubScript) {
-          auto base_metrics = run->GetMetrics();
-          y_offset += base_metrics.GetSubOffset();
+        auto element_ascent = metrics.GetMaxAscent();
+        auto element_descent = metrics.GetMaxDescent();
+        if (cva == CharacterVerticalAlignment::kTextTop ||
+            cva == CharacterVerticalAlignment::kTextBottom) {
+          container_ascent = GetContentBaseline() - GetContentTop();
+          container_descent = GetContentBottom() - GetContentBaseline();
+        }
+        if (cva != CharacterVerticalAlignment::kBaseLine) {
+          y_offset += LayoutMeasurer::CalcElementY(
+              cva, container_ascent, container_descent, element_ascent,
+              element_descent);
+          if (cva == CharacterVerticalAlignment::kSuperScript) {
+            auto base_metrics = run->GetMetrics();
+            y_offset += base_metrics.GetSupOffset();
+          }
+          if (cva == CharacterVerticalAlignment::kSubScript) {
+            auto base_metrics = run->GetMetrics();
+            y_offset += base_metrics.GetSubOffset();
+          }
+        }
+        if (drawer->GetRun()->GetType() == RunType::kInlineObject ||
+            drawer->GetRun()->GetType() == RunType::kFloatObject) {
+          auto paragraph = run->GetParagraph();
+          if (paragraph) {
+            auto& style_manager = paragraph->style_manager_;
+            auto base_line_offset = style_manager->GetBaselineOffset(
+                drawer->GetRun()->GetStartCharPos());
+            y_offset += base_line_offset;
+          }
         }
       }
       if (drawer->GetRun()->GetType() == RunType::kInlineObject ||
           drawer->GetRun()->GetType() == RunType::kFloatObject) {
-        auto paragraph = run->GetParagraph();
-        if (paragraph) {
-          auto& style_manager = paragraph->style_manager_;
-          auto base_line_offset = style_manager->GetBaselineOffset(
-              drawer->GetRun()->GetStartCharPos());
-          y_offset += base_line_offset;
-        }
-
         auto y = GetLineTop() + y_offset;
         drawer->GetRun()->GetRunDelegate()->SetOffset(
             start_offset, y + metrics.GetMaxAscent());
@@ -406,6 +493,7 @@ void TextLineImpl::ClearForRelayout() {
   empty_ = true;
   layouted_ = false;
   max_ascent_ = max_descent_ = 0;
+  top_extra_ = bottom_extra_ = 0;
   current_available_range_index_ = 0;
 }
 bool TextLineImpl::IsLastLineOfParagraph() const {

--- a/src/textlayout/text_line_impl.h
+++ b/src/textlayout/text_line_impl.h
@@ -53,6 +53,7 @@ class TextLineImpl : public TextLine {
  public:
   LayoutPosition UpdateLine(LayoutPosition pos, float max_ascent,
                             float max_descent, float desired_height);
+  void AdjustInlineObjectLineBox();
   LineRange* GetCurrentRange() const {
     return range_lst_[current_available_range_index_].get();
   }
@@ -103,6 +104,7 @@ class TextLineImpl : public TextLine {
   std::vector<std::unique_ptr<LineRange>> range_lst_;
   std::vector<std::unique_ptr<DrawerPiece>> drawer_list_;
   std::vector<std::unique_ptr<BaseRun>> extra_contents_;
+  float range_height_floor_ = 0;
 };
 }  // namespace tttext
 }  // namespace ttoffice

--- a/test/golden_images/vertical_align_multiple_lines_after_click.png
+++ b/test/golden_images/vertical_align_multiple_lines_after_click.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:a3c2002615d8417778fa47245ff8be549f65d52c835cd21dff55ea63c721c2db
+size 2197

--- a/test/golden_images/vertical_align_multiple_lines_before_click.png
+++ b/test/golden_images/vertical_align_multiple_lines_before_click.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0c85d28820a0c2f74291a1f883b3d22de9716e7e3469fa5f32ee0c25f3b738da
+size 2031

--- a/test/paragraph_image_test.cc
+++ b/test/paragraph_image_test.cc
@@ -2,10 +2,13 @@
 // Licensed under the Apache License Version 2.0 that can be found in the
 // LICENSE file in the root directory of this source tree.
 
+#include <textra/paragraph_style.h>
 #include <textra/platform/skity/skity_canvas_helper.h>
 #include <textra/text_layout.h>
 
+#include <cmath>
 #include <memory>
+#include <utility>
 
 #include "demos/darwin/macos/ttreaderdemo/paragraph_test.h"
 #include "gtest/gtest.h"
@@ -157,6 +160,95 @@ class ParagraphImageTest : public ::testing::Test {
   void TestHalfLeading() {
     TestHelper(&ParagraphTest::TestHalfLeading, "half_leading.png");
   }
+
+  void TestVerticalAlignMultipleLinesCase(float length_alignment,
+                                          const char* out_file_name) {
+    constexpr float kWidth = 220.f;
+    constexpr float kFontSize = 14.f;
+    constexpr float kLineHeight = 30.f;
+    constexpr float kObjectSize = 20.f;
+
+    auto layout_text = [&](uint32_t object_color) {
+      auto paragraph = std::make_unique<ParagraphImpl>();
+      ParagraphStyle paragraph_style;
+      Style text_style;
+      text_style.SetTextSize(kFontSize);
+      paragraph_style.SetDefaultStyle(text_style);
+      paragraph_style.SetLineHeightInPx(kLineHeight, RulerType::kExact);
+      paragraph_style.SetInlineVerticalAlignmentMode(
+          InlineVerticalAlignmentMode::kLineBox);
+      paragraph->SetParagraphStyle(&paragraph_style);
+      paragraph->AddTextRun(&text_style, "x", 1);
+
+      class CaseShape final : public RunDelegate {
+       public:
+        explicit CaseShape(uint32_t color) : color_(color) {}
+        float GetAscent() const override { return -kObjectSize; }
+        float GetDescent() const override { return 0.f; }
+        float GetAdvance() const override { return kObjectSize; }
+        void Draw(ICanvasHelper* canvas, float x, float y) override {
+          auto painter = canvas->CreatePainter();
+          painter->SetFillColor(color_);
+          canvas->DrawRect(x, y, x + kObjectSize, y + kObjectSize,
+                           painter.get());
+        }
+
+       private:
+        uint32_t color_;
+      };
+
+      const CharacterVerticalAlignment alignments[] = {
+          CharacterVerticalAlignment::kMiddle,
+          CharacterVerticalAlignment::kMiddle,
+          CharacterVerticalAlignment::kTop,
+          CharacterVerticalAlignment::kBottom,
+          CharacterVerticalAlignment::kTextTop,
+          CharacterVerticalAlignment::kTextBottom,
+          CharacterVerticalAlignment::kSuperScript,
+          CharacterVerticalAlignment::kBaseLine,
+          CharacterVerticalAlignment::kSubScript,
+      };
+      for (const float baseline_offset :
+           {-length_alignment, length_alignment}) {
+        Style length_style = text_style;
+        length_style.SetBaselineOffset(baseline_offset);
+        paragraph->AddShapeRun(
+            &length_style, std::make_shared<CaseShape>(object_color), false);
+        for (const auto alignment : alignments) {
+          Style object_style = text_style;
+          object_style.SetVerticalAlignment(alignment);
+          paragraph->AddShapeRun(
+              &object_style, std::make_shared<CaseShape>(object_color), false);
+        }
+      }
+      paragraph->AddTextRun(&text_style, "e", 1);
+
+      TTTextContext context;
+      TextLayout layout(TestUtils::getRealShaper());
+      auto region = std::make_unique<LayoutRegion>(kWidth, 300.f);
+      layout.Layout(paragraph.get(), region.get(), context);
+      return std::make_pair(std::move(paragraph), std::move(region));
+    };
+
+    auto [image_paragraph, image_region] = layout_text(0xFF41A5F5);
+    auto [view_paragraph, view_region] = layout_text(0xFFFF7043);
+    const float image_height = image_region->GetLayoutedHeight();
+    const float view_height = view_region->GetLayoutedHeight();
+    skity::Bitmap bitmap(
+        static_cast<uint32_t>(kWidth),
+        static_cast<uint32_t>(std::ceil(image_height + view_height)),
+        skity::AlphaType::kPremul_AlphaType, skity::ColorType::kRGBA);
+    auto canvas = skity::Canvas::MakeSoftwareCanvas(&bitmap);
+    canvas->DrawColor(skity::Color_WHITE);
+    SkityCanvasHelper canvas_helper(canvas.get());
+    TestUtils::DrawLayoutRegionOnCanvas(canvas_helper, *image_region);
+    canvas_helper.Translate(0.f, image_height);
+    TestUtils::DrawLayoutRegionOnCanvas(canvas_helper, *view_region);
+
+    auto codec = skity::Codec::MakePngCodec();
+    auto data = codec->Encode(bitmap.GetPixmap().get());
+    data->WriteToFile(out_file_name);
+  }
 };
 
 TEST_F(ParagraphImageTest, TestSupSub) { TestSupSub(); }
@@ -206,3 +298,11 @@ TEST_F(ParagraphImageTest, TestModifyHAlignAfterLayout) {
 TEST_F(ParagraphImageTest, TestApplyStyleRange) { TestApplyStyleRange(); }
 TEST_F(ParagraphImageTest, TestTextShadow) { TestTextShadow(); }
 TEST_F(ParagraphImageTest, TestHalfLeading) { TestHalfLeading(); }
+TEST_F(ParagraphImageTest, VerticalAlignMultipleLinesCaseBeforeClick) {
+  TestVerticalAlignMultipleLinesCase(
+      0.f, "vertical_align_multiple_lines_before_click.png");
+}
+TEST_F(ParagraphImageTest, VerticalAlignMultipleLinesCaseAfterClick) {
+  TestVerticalAlignMultipleLinesCase(
+      20.f, "vertical_align_multiple_lines_after_click.png");
+}

--- a/test/paragraph_style_test.cc
+++ b/test/paragraph_style_test.cc
@@ -11,6 +11,16 @@
 #include "test_src.h"
 #include "test_utils.h"
 
+TEST(ParagraphStyleTest, InlineVerticalAlignmentModeIsOptIn) {
+  ParagraphStyle style;
+  EXPECT_EQ(style.GetInlineVerticalAlignmentMode(),
+            InlineVerticalAlignmentMode::kLegacy);
+
+  style.SetInlineVerticalAlignmentMode(InlineVerticalAlignmentMode::kLineBox);
+  EXPECT_EQ(style.GetInlineVerticalAlignmentMode(),
+            InlineVerticalAlignmentMode::kLineBox);
+}
+
 TEST(ParagraphStyleTest, LineGapTest) {
   std::unique_ptr<Paragraph> paragraph = TTParagraph::Create();
   auto layout_page = ParagraphStyleTestClass::LineGapTest(

--- a/test/text_layout_test.cc
+++ b/test/text_layout_test.cc
@@ -38,6 +38,26 @@ class MockInlineObject : public RunDelegate {
   float descent_;
 };
 
+class HeightSensitiveLayoutRegion : public LayoutRegion {
+ public:
+  HeightSensitiveLayoutRegion() : LayoutRegion(100.f, 200.f) {}
+
+  std::vector<std::array<float, 2>> GetRangeList(float* top, float range_height,
+                                                 float start_indent,
+                                                 float end_indent) override {
+    ++range_query_count_;
+    // The fallback after repeated queries keeps a broken implementation from
+    // hanging the test while still exposing a non-converging relayout loop.
+    const bool use_tall_range = range_height >= 40.f || range_query_count_ > 6;
+    return {{start_indent, (use_tall_range ? 80.f : 100.f) - end_indent}};
+  }
+
+  int GetRangeQueryCount() const { return range_query_count_; }
+
+ private:
+  int range_query_count_ = 0;
+};
+
 class TextLayoutTest : public ::testing::Test {
  public:
   ::TypefaceRef CreateFixedSizeMockTypeface() {
@@ -701,6 +721,262 @@ TEST_F(TextLayoutTest, InlineObjectRespectsAtLeastLineHeight) {
   ASSERT_NE(line, nullptr);
   EXPECT_FLOAT_EQ(line->GetContentHeight(), kObjectDescent - kObjectAscent);
   EXPECT_FLOAT_EQ(line->GetLineHeight(), kLineHeight);
+}
+
+TEST_F(TextLayoutTest, ExactLineBoxOnlyExpandsInlineObjectLine) {
+  constexpr float kLineHeight = 20.f;
+
+  auto para = std::make_unique<ParagraphImpl>();
+  ParagraphStyle para_style;
+  Style text_style;
+  text_style.SetTextSize(40.f);
+  para_style.SetDefaultStyle(text_style);
+  para_style.SetLineHeightInPx(kLineHeight, RulerType::kExact);
+  para_style.SetInlineVerticalAlignmentMode(
+      InlineVerticalAlignmentMode::kLineBox);
+  para->SetParagraphStyle(&para_style);
+  para->AddTextRun(&text_style, "first\nsecond", 12);
+  para->AddShapeRun(&text_style,
+                    std::make_shared<MockInlineObject>(20.f, -20.f, 10.f),
+                    false);
+  para->AddTextRun(&text_style, "\nthird", 6);
+
+  TTTextContext context;
+  TextLayout layout(GetFixedSizeMockShaper());
+  auto region = std::make_unique<LayoutRegion>(1000.f, 200.f);
+  layout.Layout(para.get(), region.get(), context);
+
+  ASSERT_EQ(region->GetLineCount(), 3u);
+  EXPECT_FLOAT_EQ(region->GetLine(0)->GetLineHeight(), kLineHeight);
+  EXPECT_FLOAT_EQ(region->GetLine(1)->GetLineHeight(), 30.f);
+  EXPECT_FLOAT_EQ(region->GetLine(2)->GetLineHeight(), kLineHeight);
+  EXPECT_GE(region->GetLine(1)->GetLineBaseLine() - 20.f,
+            region->GetLine(1)->GetLineTop());
+  EXPECT_LE(region->GetLine(1)->GetLineBaseLine() + 10.f,
+            region->GetLine(1)->GetLineBottom());
+  EXPECT_LE(region->GetLine(0)->GetLineBottom(),
+            region->GetLine(1)->GetLineTop());
+  EXPECT_LE(region->GetLine(1)->GetLineBottom(),
+            region->GetLine(2)->GetLineTop());
+}
+
+TEST_F(TextLayoutTest, ExactLineBoxKeepsInlineObjectOutOfTextMetrics) {
+  auto para = std::make_unique<ParagraphImpl>();
+  ParagraphStyle para_style;
+  Style text_style;
+  text_style.SetTextSize(20.f);
+  para_style.SetDefaultStyle(text_style);
+  para_style.SetLineHeightInPx(20.f, RulerType::kExact);
+  para_style.SetInlineVerticalAlignmentMode(
+      InlineVerticalAlignmentMode::kLineBox);
+  para->SetParagraphStyle(&para_style);
+  para->AddTextRun(&text_style, "A");
+  para->AddShapeRun(
+      &text_style, std::make_shared<MockInlineObject>(10.f, -60.f, 0.f), false);
+
+  TTTextContext context;
+  TextLayout layout(GetFixedSizeMockShaper());
+  auto region = std::make_unique<LayoutRegion>(100.f, 100.f);
+  layout.Layout(para.get(), region.get(), context);
+
+  ASSERT_EQ(region->GetLineCount(), 1u);
+  EXPECT_FLOAT_EQ(region->GetLine(0)->GetContentHeight(), 20.f);
+  EXPECT_FLOAT_EQ(region->GetLine(0)->GetLineHeight(), 65.f);
+}
+
+TEST_F(TextLayoutTest, ExactLineBoxJointlyFitsTopAndBottomObjects) {
+  auto para = std::make_unique<ParagraphImpl>();
+  ParagraphStyle para_style;
+  Style text_style;
+  text_style.SetTextSize(20.f);
+  Style top_style = text_style;
+  top_style.SetVerticalAlignment(CharacterVerticalAlignment::kTop);
+  Style bottom_style = text_style;
+  bottom_style.SetVerticalAlignment(CharacterVerticalAlignment::kBottom);
+  para_style.SetDefaultStyle(text_style);
+  para_style.SetLineHeightInPx(20.f, RulerType::kExact);
+  para_style.SetInlineVerticalAlignmentMode(
+      InlineVerticalAlignmentMode::kLineBox);
+  para->SetParagraphStyle(&para_style);
+  para->AddTextRun(&text_style, "A");
+  auto top_object = std::make_shared<MockInlineObject>(10.f, -40.f, 0.f);
+  auto bottom_object = std::make_shared<MockInlineObject>(10.f, -40.f, 0.f);
+  para->AddShapeRun(&top_style, top_object, false);
+  para->AddShapeRun(&bottom_style, bottom_object, false);
+
+  TTTextContext context;
+  TextLayout layout(GetFixedSizeMockShaper());
+  auto region = std::make_unique<LayoutRegion>(100.f, 100.f);
+  layout.Layout(para.get(), region.get(), context);
+
+  ASSERT_EQ(region->GetLineCount(), 1u);
+  auto* line = region->GetLine(0);
+  EXPECT_FLOAT_EQ(line->GetLineHeight(), 40.f);
+  EXPECT_FLOAT_EQ(top_object->GetYOffset(), line->GetLineTop());
+  EXPECT_FLOAT_EQ(bottom_object->GetYOffset(), line->GetLineBottom() - 40.f);
+}
+
+TEST_F(TextLayoutTest, ExactLineBoxRelayoutUsesResolvedObjectHeight) {
+  auto para = std::make_unique<ParagraphImpl>();
+  ParagraphStyle para_style;
+  Style text_style;
+  text_style.SetTextSize(20.f);
+  para_style.SetDefaultStyle(text_style);
+  para_style.SetLineHeightInPx(20.f, RulerType::kExact);
+  para_style.SetInlineVerticalAlignmentMode(
+      InlineVerticalAlignmentMode::kLineBox);
+  para->SetParagraphStyle(&para_style);
+  para->AddTextRun(&text_style, "A");
+  para->AddShapeRun(
+      &text_style, std::make_shared<MockInlineObject>(10.f, -60.f, 0.f), false);
+  para->AddTextRun(&text_style, "B");
+
+  TTTextContext context;
+  TextLayout layout(GetFixedSizeMockShaper());
+  auto region = std::make_unique<HeightSensitiveLayoutRegion>();
+  auto* region_ptr = region.get();
+  layout.Layout(para.get(), region.get(), context);
+
+  ASSERT_EQ(region->GetLineCount(), 1u);
+  EXPECT_LE(region_ptr->GetRangeQueryCount(), 4);
+  EXPECT_FLOAT_EQ(region->GetLine(0)->GetLineHeight(), 65.f);
+}
+
+TEST_F(TextLayoutTest, ExactLineBoxMatchesCssVerticalAlignGeometry) {
+  constexpr float kFontSize = 40.f;
+  constexpr float kLineHeight = 20.f;
+  struct Expectation {
+    CharacterVerticalAlignment alignment;
+    float object_height;
+    float line_height;
+    float object_top;
+  };
+  const Expectation expectations[] = {
+      {CharacterVerticalAlignment::kBaseLine, 10.f, 20.f, 10.f},
+      {CharacterVerticalAlignment::kSuperScript, 10.f, 23.2f, 0.f},
+      {CharacterVerticalAlignment::kSubScript, 10.f, 28.f, 18.f},
+      {CharacterVerticalAlignment::kMiddle, 10.f, 20.f, 5.f},
+      {CharacterVerticalAlignment::kTextTop, 10.f, 30.f, 0.f},
+      {CharacterVerticalAlignment::kTextBottom, 10.f, 30.f, 20.f},
+      {CharacterVerticalAlignment::kTop, 10.f, 20.f, 0.f},
+      {CharacterVerticalAlignment::kBottom, 10.f, 20.f, 10.f},
+      {CharacterVerticalAlignment::kBaseLine, 60.f, 60.f, 0.f},
+      {CharacterVerticalAlignment::kSuperScript, 60.f, 73.2f, 0.f},
+      {CharacterVerticalAlignment::kSubScript, 60.f, 60.f, 0.f},
+      {CharacterVerticalAlignment::kMiddle, 60.f, 60.f, 0.f},
+      {CharacterVerticalAlignment::kTextTop, 60.f, 60.f, 0.f},
+      {CharacterVerticalAlignment::kTextBottom, 60.f, 60.f, 0.f},
+      {CharacterVerticalAlignment::kTop, 60.f, 60.f, 0.f},
+      {CharacterVerticalAlignment::kBottom, 60.f, 60.f, 0.f},
+  };
+
+  for (const auto& expectation : expectations) {
+    SCOPED_TRACE(static_cast<int>(expectation.alignment));
+    SCOPED_TRACE(expectation.object_height);
+    auto para = std::make_unique<ParagraphImpl>();
+    ParagraphStyle para_style;
+    Style text_style;
+    text_style.SetTextSize(kFontSize);
+    Style object_style = text_style;
+    object_style.SetVerticalAlignment(expectation.alignment);
+    para_style.SetDefaultStyle(text_style);
+    para_style.SetLineHeightInPx(kLineHeight, RulerType::kExact);
+    para_style.SetInlineVerticalAlignmentMode(
+        InlineVerticalAlignmentMode::kLineBox);
+    para->SetParagraphStyle(&para_style);
+    para->AddTextRun(&text_style, "A", 1);
+    auto object = std::make_shared<MockInlineObject>(
+        10.f, -expectation.object_height, 0.f);
+    para->AddShapeRun(&object_style, object, false);
+    para->AddTextRun(&text_style, "A", 1);
+
+    TTTextContext context;
+    TextLayout layout(GetFixedSizeMockShaper());
+    auto region = std::make_unique<LayoutRegion>(1000.f, 300.f);
+    layout.Layout(para.get(), region.get(), context);
+
+    ASSERT_EQ(region->GetLineCount(), 1u);
+    EXPECT_NEAR(region->GetLine(0)->GetLineHeight(), expectation.line_height,
+                0.001f);
+    EXPECT_NEAR(object->GetYOffset() - region->GetLine(0)->GetLineTop(),
+                expectation.object_top, 0.001f);
+  }
+}
+
+TEST_F(TextLayoutTest,
+       LineBoxSuperAndSubUseContainingInlineFontInsteadOfObjectHeight) {
+  auto para = std::make_unique<ParagraphImpl>();
+  ParagraphStyle para_style;
+  Style parent_style;
+  parent_style.SetTextSize(40.f);
+  para_style.SetDefaultStyle(parent_style);
+  para_style.SetLineHeightInPx(20.f, RulerType::kExact);
+  para_style.SetInlineVerticalAlignmentMode(
+      InlineVerticalAlignmentMode::kLineBox);
+  para->SetParagraphStyle(&para_style);
+
+  // The object is inside a nested 12 px inline, while the paragraph root is
+  // 40 px. Its computed style is the containing inline style available after
+  // the DOM has been flattened into TTText runs.
+  Style containing_inline_style;
+  containing_inline_style.SetTextSize(12.f);
+  containing_inline_style.SetVerticalAlignment(
+      CharacterVerticalAlignment::kSuperScript);
+  Style sub_style = containing_inline_style;
+  sub_style.SetVerticalAlignment(CharacterVerticalAlignment::kSubScript);
+
+  para->AddTextRun(&parent_style, "x");
+  para->AddShapeRun(&containing_inline_style,
+                    std::make_shared<MockInlineObject>(20.f, -60.f, 0.f),
+                    false);
+  para->AddShapeRun(
+      &sub_style, std::make_shared<MockInlineObject>(20.f, -60.f, 0.f), false);
+
+  TTTextContext context;
+  TextLayout layout(GetFixedSizeMockShaper());
+  auto region = std::make_unique<LayoutRegion>(100.f, 100.f);
+  layout.Layout(para.get(), region.get(), context);
+
+  ASSERT_EQ(region->GetLineCount(), 1u);
+  auto* line = region->GetLine(0);
+  ASSERT_NE(line, nullptr);
+  const float baseline = line->GetLineBaseLine();
+
+  float super_rect[4]{};
+  float sub_rect[4]{};
+  line->GetCharBoundingRect(super_rect, 1);
+  line->GetCharBoundingRect(sub_rect, 2);
+
+  // CSS super/sub use the parent inline's font metrics. With the current
+  // fallback ratios, a 12 px inherited font shifts by -3.96 px / +2.4 px even
+  // though the replaced inline itself is 60 px tall.
+  EXPECT_NEAR(super_rect[1] - baseline, -63.96f, 0.001f);
+  EXPECT_NEAR(sub_rect[1] - baseline, -57.6f, 0.001f);
+  EXPECT_NEAR(line->GetLineHeight(), 66.36f, 0.001f);
+}
+
+TEST_F(TextLayoutTest, ExactLineHeightDoesNotExpandInlineObjectLine) {
+  constexpr float kLineHeight = 20.f;
+
+  auto para = std::make_unique<ParagraphImpl>();
+  ParagraphStyle para_style;
+  Style text_style;
+  text_style.SetTextSize(40.f);
+  para_style.SetDefaultStyle(text_style);
+  para_style.SetLineHeightInPx(kLineHeight, RulerType::kExact);
+  para->SetParagraphStyle(&para_style);
+  para->AddTextRun(&text_style, "text", 4);
+  para->AddShapeRun(&text_style,
+                    std::make_shared<MockInlineObject>(20.f, -20.f, 10.f),
+                    false);
+
+  TTTextContext context;
+  TextLayout layout(GetFixedSizeMockShaper());
+  auto region = std::make_unique<LayoutRegion>(1000.f, 200.f);
+  layout.Layout(para.get(), region.get(), context);
+
+  ASSERT_EQ(region->GetLineCount(), 1u);
+  EXPECT_FLOAT_EQ(region->GetLine(0)->GetLineHeight(), kLineHeight);
 }
 
 // WriteDirection decides the position of the ellipsis


### PR DESCRIPTION
Adds a CSS-specific line-height rule for consumers that need CSS inline formatting semantics.\n\n- Normal text keeps the specified line height, even when glyph ink is taller.\n- Atomic inline objects and baseline-shifted runs expand only their containing line.\n- Neighboring lines retain the specified height.\n- Existing exact and at-least behaviors remain unchanged.\n\nTests:\n- TextLayoutLiteTest (185 tests)\n- Three-line isolation coverage for inline objects and baseline-shifted text\n- Exact-line-height compatibility coverage