### PR TITLE
Fix exact line box for shifted inline text

### DIFF
--- a/src/textlayout/text_layout_impl.cc
+++ b/src/textlayout/text_layout_impl.cc
@@ -331,6 +331,12 @@ float TextLayoutImpl::AddWordListToRunRange(LineRange* range,
           paragraph.style_manager_->GetBaselineOffset(run->GetStartCharPos());
       run_metrics.ApplyBaselineOffset(baseline_offset);
       metrics->UpdateMax(run_metrics);
+      if (use_exact_text_line_box && run->IsTextRun() &&
+          baseline_offset != 0.f &&
+          LayoutMeasurer::ResolveCharacterVerticalAlignment(run) ==
+              CharacterVerticalAlignment::kBaseLine) {
+        max_desired_height = std::max(max_desired_height, metrics->GetHeight());
+      }
     }
     auto end_char_in_run = pos.GetRunIdx() == end_pos.GetRunIdx()
                                ? end_pos.GetCharIdx()

--- a/test/text_layout_test.cc
+++ b/test/text_layout_test.cc
@@ -760,6 +760,32 @@ TEST_F(TextLayoutTest, ExactLineBoxOnlyExpandsInlineObjectLine) {
             region->GetLine(2)->GetLineTop());
 }
 
+TEST_F(TextLayoutTest, ExactLineBoxExpandsForShiftedInlineText) {
+  Style text_style;
+  text_style.SetTextSize(12.f);
+  Style shifted_style = text_style;
+  shifted_style.SetBaselineOffset(-20.f);
+
+  ParagraphStyle para_style;
+  para_style.SetDefaultStyle(text_style);
+  para_style.SetLineHeightInPx(28.f, RulerType::kExact);
+  para_style.SetInlineVerticalAlignmentMode(
+      InlineVerticalAlignmentMode::kLineBox);
+  auto para = std::make_unique<ParagraphImpl>();
+  para->SetParagraphStyle(&para_style);
+  para->AddTextRun(&text_style, "A");
+  para->AddTextRun(&shifted_style, "B");
+  para->AddTextRun(&text_style, "C");
+
+  TTTextContext context;
+  TextLayout layout(GetFixedSizeMockShaper());
+  auto region = std::make_unique<LayoutRegion>(100.f, 100.f);
+  layout.Layout(para.get(), region.get(), context);
+
+  ASSERT_EQ(region->GetLineCount(), 1u);
+  EXPECT_FLOAT_EQ(region->GetLine(0)->GetLineHeight(), 32.f);
+}
+
 TEST_F(TextLayoutTest, ExactLineBoxKeepsInlineObjectOutOfTextMetrics) {
   auto para = std::make_unique<ParagraphImpl>();
   ParagraphStyle para_style;


### PR DESCRIPTION
## Summary

- keep exact line height for unshifted text
- expand the kLineBox line to contain baseline-shifted inline text
- limit the behavior to baseline-aligned text with a non-zero offset, leaving keyword vertical-align and legacy mode unchanged

## Verification

- added `ExactLineBoxExpandsForShiftedInlineText` for a 12px run, 28px exact line height, and -20px baseline offset
- rebuilt `lynx_desktop` locally and verified the parity demo no longer produces a negative line top / clipped selection for `vertical-align: 20px`