### PR TITLE
[BugFix] Normalize invalid shaping cluster indices before processing

### DIFF
--- a/src/ports/shaper/skshaper/run.cc
+++ b/src/ports/shaper/skshaper/run.cc
@@ -37,6 +37,12 @@ SkShaper::RunHandler::Buffer Run::newRunBuffer() {
 }
 
 void Run::commit() {
+  const auto text_length = fTextRange.GetLength();
+  for (size_t i = 0; i < fGlyphs.size(); ++i) {
+    if (fClusterIndexes[i] >= text_length) {
+      fClusterIndexes[i] = 0;
+    }
+  }
   //  fFont.getBounds(fGlyphs.data(), fGlyphs.size(), fBounds.data(), nullptr);
 }
 }  // namespace tttext


### PR DESCRIPTION
Normalize out-of-range cluster indices in Run::commit before they are consumed by OneLineShaper, and tighten the character-to-glyph bounds assertion.