### PR TITLE
[Feature] Support paragraph default foreground for text ellipsis

### DIFF
--- a/public/textra/paragraph_style.h
+++ b/public/textra/paragraph_style.h
@@ -476,6 +476,17 @@ class L_EXPORT ParagraphStyle {
   const std::shared_ptr<RunDelegate>& GetEllipsisDelegate() const;
 
   /**
+   * @brief Uses the paragraph default foreground for a text-based ellipsis.
+   *
+   * The ellipsis keeps the font, size, shaping, baseline, decoration, and
+   * other layout properties of the truncated tail run. When enabled, only
+   * its foreground color comes from the paragraph default style.
+   * This setting does not apply to delegate-based ellipsis.
+   */
+  void SetEllipsisUsesDefaultForeground(bool enabled);
+  bool EllipsisUsesDefaultForeground() const;
+
+  /**
    * @brief Maximum number of lines before truncation.
    *
    * Controls text truncation by limiting the number of lines that can

--- a/src/textlayout/layout_drawer.cc
+++ b/src/textlayout/layout_drawer.cc
@@ -334,7 +334,7 @@ float LayoutDrawer::DrawTextRun(const BaseRun* run, uint32_t start_char_in_run,
     Painter* painter = nullptr;
     auto piece_end = char_end_pos;
     StyleRange style_range;
-    if (style_manager != nullptr) {
+    if (style_manager != nullptr && run->GetType() != RunType::kGhostRun) {
       style_manager->GetStyleRange(
           &style_range, run->GetStartCharPos() + piece_start,
           Style::ForegroundColorFlag | Style::ForegroundPainterFlag |

--- a/src/textlayout/run/ghost_run.h
+++ b/src/textlayout/run/ghost_run.h
@@ -31,7 +31,8 @@ class GhostRun : public BaseRun {
     if (!layout_style_.HasStyleAttribute(Style::TextScaleFlag)) {
       layout_style_.SetTextScale(StyleImpl::DefaultStyle().GetTextScale());
     }
-    if (!layout_style_.HasStyleAttribute(Style::ForegroundPainterFlag)) {
+    if (!layout_style_.HasStyleAttribute(Style::ForegroundColorFlag) &&
+        !layout_style_.HasStyleAttribute(Style::ForegroundPainterFlag)) {
       layout_style_.SetForegroundColor(
           StyleImpl::DefaultStyle().GetForegroundColor());
     }

--- a/src/textlayout/style/paragraph_style_impl.cc
+++ b/src/textlayout/style/paragraph_style_impl.cc
@@ -52,6 +52,8 @@ ParagraphStyleImpl& ParagraphStyleImpl::operator=(
   write_direction_ = paragraph_style.write_direction_;
   ellipsis_ = paragraph_style.ellipsis_;
   ellipsis_delegate_ = paragraph_style.ellipsis_delegate_;
+  ellipsis_uses_default_foreground_ =
+      paragraph_style.ellipsis_uses_default_foreground_;
   max_lines_ = paragraph_style.max_lines_;
   line_height_override_ = paragraph_style.line_height_override_;
   half_leading_ = paragraph_style.half_leading_;
@@ -241,6 +243,12 @@ const std::u32string& ParagraphStyle::GetEllipsis() const {
 const std::shared_ptr<RunDelegate>& ParagraphStyle::GetEllipsisDelegate()
     const {
   return impl_->GetEllipsisDelegate();
+}
+void ParagraphStyle::SetEllipsisUsesDefaultForeground(bool enabled) {
+  impl_->SetEllipsisUsesDefaultForeground(enabled);
+}
+bool ParagraphStyle::EllipsisUsesDefaultForeground() const {
+  return impl_->EllipsisUsesDefaultForeground();
 }
 uint32_t ParagraphStyle::GetMaxLines() const { return impl_->GetMaxLines(); }
 void ParagraphStyle::SetMaxLines(uint32_t max_line) {

--- a/src/textlayout/style/paragraph_style_impl.h
+++ b/src/textlayout/style/paragraph_style_impl.h
@@ -138,6 +138,12 @@ class ParagraphStyleImpl {
   const std::shared_ptr<RunDelegate>& GetEllipsisDelegate() const {
     return ellipsis_delegate_;
   }
+  void SetEllipsisUsesDefaultForeground(bool enabled) {
+    ellipsis_uses_default_foreground_ = enabled;
+  }
+  bool EllipsisUsesDefaultForeground() const {
+    return ellipsis_uses_default_foreground_;
+  }
   uint32_t GetMaxLines() const { return max_lines_; }
   void SetMaxLines(uint32_t max_line) {
     max_lines_ =
@@ -178,6 +184,7 @@ class ParagraphStyleImpl {
   WriteDirection write_direction_;
   std::u32string ellipsis_;
   std::shared_ptr<RunDelegate> ellipsis_delegate_;
+  bool ellipsis_uses_default_foreground_{false};
   uint32_t max_lines_;
   bool line_height_override_;
   bool half_leading_;

--- a/src/textlayout/text_line_impl.cc
+++ b/src/textlayout/text_line_impl.cc
@@ -533,7 +533,11 @@ void TextLineImpl::StripByEllipsis(const char32_t* ellipsis) {
       return;
     }
     auto font = run->shape_result_.FontByCharId(0);
-    auto run_style = run->GetLayoutStyle();
+    StyleImpl run_style = run->GetLayoutStyle();
+    if (para_style.EllipsisUsesDefaultForeground()) {
+      const auto& default_style = para_style.GetDefaultStyleImpl();
+      run_style.SetForegroundColor(default_style.GetForegroundColor());
+    }
     std::unique_ptr<BaseRun> ellipsis_run;
     if (ellipsis != nullptr && ellipsis_len > 0) {
       ellipsis_run = std::make_unique<GhostRun>(paragraph_, run_style, 0,

--- a/test/BUILD.gn
+++ b/test/BUILD.gn
@@ -15,6 +15,7 @@ executable("TextLayoutLiteTest") {
   sources = [
     "//demos/darwin/macos/ttreaderdemo/paragraph_test.cc",
     "boundary_analyst_test.cc",
+    "ellipsis_foreground_color_test.cc",
     "inline_block_test.cc",
     "justify_analyst_test.cc",
     "layout_drawer_test.cc",

--- a/test/ellipsis_foreground_color_test.cc
+++ b/test/ellipsis_foreground_color_test.cc
@@ -1,0 +1,110 @@
+// Copyright 2026 The Lynx Authors. All rights reserved.
+// Licensed under the Apache License Version 2.0 that can be found in the
+// LICENSE file in the root directory of this source tree.
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+#include <textra/layout_drawer.h>
+#include <textra/layout_region.h>
+#include <textra/paragraph_style.h>
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "mocks.h"
+#include "src/textlayout/paragraph_impl.h"
+#include "test_utils.h"
+
+using namespace ttoffice::tttext;
+using namespace ::testing;
+
+namespace {
+
+constexpr float kTextSize = 10.f;
+constexpr float kLineWidth = 130.f;
+
+std::unique_ptr<ParagraphImpl> MakeTruncatedParagraph(
+    bool uses_default_foreground) {
+  auto paragraph = std::make_unique<ParagraphImpl>();
+  auto& paragraph_style = paragraph->GetParagraphStyle();
+
+  Style default_style;
+  default_style.SetTextSize(kTextSize);
+  default_style.SetForegroundColor(TTColor::BLUE);
+  paragraph_style.SetDefaultStyle(default_style);
+  paragraph_style.SetMaxLines(1);
+  paragraph_style.SetEllipsis("...");
+  paragraph_style.SetEllipsisUsesDefaultForeground(uses_default_foreground);
+
+  Style tail_style = default_style;
+  tail_style.SetForegroundColor(TTColor::RED);
+
+  Style leading_style = default_style;
+  leading_style.SetForegroundColor(TTColor::GREEN);
+  paragraph->AddTextRun(&leading_style, "AAAAAAAAAA");
+  paragraph->AddTextRun(&tail_style, "BBBBBBBBBBBBBBBBBBBB");
+  return paragraph;
+}
+
+struct DrawRecord {
+  uint32_t glyph_count;
+  TTColor fill_color;
+};
+
+std::vector<DrawRecord> Draw(LayoutRegion* region,
+                             MockCanvasHelper* canvas_helper) {
+  std::vector<DrawRecord> records;
+  ON_CALL(*canvas_helper, CreatePainter()).WillByDefault(Invoke([]() {
+    return std::make_unique<Painter>();
+  }));
+  EXPECT_CALL(*canvas_helper, DrawGlyphs(_, _, _, nullptr, 0, _, _, _, _, _))
+      .WillRepeatedly(Invoke([&](const ITypefaceHelper*, uint32_t glyph_count,
+                                 const uint16_t*, const char*, uint32_t, float,
+                                 float, float*, float*, Painter* painter) {
+        records.push_back(DrawRecord{glyph_count, painter->GetFillColor()});
+      }));
+  LayoutDrawer drawer(canvas_helper);
+  drawer.DrawLayoutPage(region);
+  return records;
+}
+
+}  // namespace
+
+TEST(EllipsisForegroundColorTest, DrawsDefaultForegroundColor) {
+  auto paragraph = MakeTruncatedParagraph(true);
+  auto region =
+      TestUtils::SimpleLayoutParagraphByWidth(paragraph.get(), kLineWidth);
+
+  NiceMock<MockCanvasHelper> canvas_helper;
+  auto records = Draw(region.get(), &canvas_helper);
+
+  ASSERT_FALSE(records.empty());
+  EXPECT_EQ(records.back().glyph_count, 3u);
+  EXPECT_EQ(records.back().fill_color, TTColor::BLUE);
+}
+
+TEST(EllipsisForegroundColorTest, WithoutOverrideKeepsTailForegroundColor) {
+  auto paragraph = MakeTruncatedParagraph(false);
+  auto region =
+      TestUtils::SimpleLayoutParagraphByWidth(paragraph.get(), kLineWidth);
+  NiceMock<MockCanvasHelper> canvas_helper;
+  auto records = Draw(region.get(), &canvas_helper);
+
+  ASSERT_FALSE(records.empty());
+  EXPECT_EQ(records.back().glyph_count, 3u);
+  EXPECT_EQ(records.back().fill_color, TTColor::RED);
+}
+
+TEST(EllipsisForegroundColorTest, NoTruncationDoesNotDrawEllipsis) {
+  auto paragraph = MakeTruncatedParagraph(true);
+  auto region = TestUtils::SimpleLayoutParagraphByWidth(paragraph.get(), 400.f);
+
+  NiceMock<MockCanvasHelper> canvas_helper;
+  auto records = Draw(region.get(), &canvas_helper);
+
+  ASSERT_FALSE(records.empty());
+  for (const auto& record : records) {
+    EXPECT_NE(record.glyph_count, 3u);
+  }
+}


### PR DESCRIPTION
Add an opt-in paragraph style policy that lets a text-based ellipsis use the paragraph default foreground color while keeping the truncated tail run's font, size, weight, baseline, decoration and shaping attributes.

Synthesized ellipsis runs do not belong to the paragraph text, so the layout drawer now skips the paragraph StyleManager lookup for ghost runs and uses the style captured when the ellipsis run is created. The ghost run fallback color is applied only when neither a foreground color nor a foreground painter is explicitly set, so an inherited tail color is no longer overwritten by black.

TEST: EllipsisForegroundColorTest.* (3 tests passed)