### PR TITLE
[Optimize][iOS] Reuse existing CoreText font metrics

### DIFF
--- a/public/textra/platform/ios/typeface_coretext.h
+++ b/public/textra/platform/ios/typeface_coretext.h
@@ -98,6 +98,12 @@ class TypefaceCoreText : public ITypefaceHelper {
   // CGFont.
 
   void OnCreateFontInfo(FontInfo* info, float font_size) const override {
+    if (font_size == CTFontGetSize(font_ref_)) {
+      *info =
+          FontInfo{static_cast<float>(-CTFontGetAscent(font_ref_)),
+                   static_cast<float>(CTFontGetDescent(font_ref_)), font_size};
+      return;
+    }
     auto baseCGFont = CTFontCopyGraphicsFont(font_ref_, nullptr);
     // The last parameter (CTFontDescriptorRef attributes) *must* be nullptr.
     // If non-nullptr then with fonts with variation axes, the copy will fail in


### PR DESCRIPTION
## Summary

`TypefaceCoreText::OnCreateFontInfo` currently always extracts a `CGFont` via `CTFontCopyGraphicsFont` and reconstructs a `CTFont` with `CTFontCreateWithGraphicsFont` to read ascent/descent, even when the requested size equals the size of the already-retained `font_ref_`.

This adds a fast path: when `font_size == CTFontGetSize(font_ref_)`, read the metrics directly from the existing `font_ref_` and return early. The original CGFont/CTFont reconstruction path is preserved unchanged for the different-size case.

## Motivation

The metrics-size-unchanged case is common in practice, and the CGFont extraction + CTFont reconstruction is measurable overhead on the text layout path. Reusing the existing CTFont avoids that redundant work while keeping behavior identical.

## Changes

- `public/textra/platform/ios/typeface_coretext.h`: early return using `CTFontGetAscent`/`CTFontGetDescent` on `font_ref_` when the size matches.

## Test

Existing CoreText path is unchanged for mismatched sizes; the fast path returns the same ascent/descent/size values that the reconstruction path would produce for the same font at its native size.